### PR TITLE
Bump charm-test required version to fix unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ commands =
     rm -f {toxinidir}/lib/charms/layer/__init__.py
 deps =
     -r{toxinidir}/requirements.txt
-    git+git://github.com/freeekanayaka/fixtures@master#egg=fixtures-3.0.1
-    charm-test>=0.1.4
+    fixtures
+    charm-test>=0.2.0
     fakesleep
     coverage
 setenv =


### PR DESCRIPTION
The latest charm-test release has been fixed so it doesn't require the custom fixtures fork from my repository anymore.