### PR TITLE
Add configuration for setting the Jenkins URL.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,3 +48,9 @@ options:
     default: 1
     description: |
       Number of executors to configure for jenkins master.
+  public-url:
+    type: string
+    default: ""
+    description: |
+      Public url of Jenkins frontend, including the hostname and prefix. This
+      is used by Jenkins whenever generating full links.

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -1,20 +1,17 @@
 import requests
-
-import jenkins
-
+from urllib.parse import urljoin, urlparse
 from urllib.error import (
     URLError,
     HTTPError,
 )
 from urllib.request import Request
 
+import jenkins
 from charmhelpers.core import hookenv
 from charmhelpers.core.decorators import retry_on_exception
-
 from charmhelpers.core.hookenv import ERROR
 
 from charms.layer.jenkins.credentials import Credentials
-from charms.layer.jenkins.service import URL
 
 RETRIABLE = (URLError, jenkins.JenkinsException)
 GET_TOKEN_SCRIPT = """
@@ -34,13 +31,21 @@ user.addProperty(property)
 class Api(object):
     """Encapsulate operations on the Jenkins master."""
 
+    @property
+    def url(self):
+        config = hookenv.config()
+        prefix = urlparse(config["public-url"]).path
+        if len(prefix) > 0 and prefix[-1] != '/':
+            prefix += '/'
+        return urljoin("http://localhost:8080/", prefix)
+
     def wait(self):
         self._make_client()
 
     def version(self):
         """Return the version."""
         self.wait()
-        response = requests.get(URL)
+        response = requests.get(self.url)
         return response.headers["X-Jenkins"]
 
     def update_password(self, username, password):
@@ -94,7 +99,7 @@ class Api(object):
         """Reload configuration from disk."""
         hookenv.log("Reloading configuration from disk")
         client = self._make_client()
-        request = Request(client._build_url("/reload"), method="POST")
+        request = Request(urljoin(self.url, "reload"), method="POST")
         try:
             client.jenkins_open(request)
         except HTTPError as error:
@@ -103,7 +108,7 @@ class Api(object):
             if error.code != 503:
                 hookenv.log("Unexpected HTTP response code '%d'" % error.code)
                 raise
-            if error.url != client._build_url("/"):
+            if error.url != self.url:
                 hookenv.log("Unexpected HTTP response url '%s'" % error.url)
                 raise
         else:
@@ -119,10 +124,10 @@ class Api(object):
 
         # TODO: also handle regenerated tokens
         if token is None:
-            client = jenkins.Jenkins(URL, user, creds.password())
+            client = jenkins.Jenkins(self.url, user, creds.password())
             token = client.run_script(GET_TOKEN_SCRIPT.format(user)).strip()
             creds.token(token)
 
-        client = jenkins.Jenkins(URL, user, token)
+        client = jenkins.Jenkins(self.url, user, token)
         client.get_whoami()
         return client

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import templating
@@ -28,3 +29,54 @@ class Configuration(object):
         if os.path.exists(paths.LEGACY_BOOTSTRAP_FLAG):
             hookenv.log("Removing legacy bootstrap flag file")
             os.unlink(paths.LEGACY_BOOTSTRAP_FLAG)
+
+    def set_url(self):
+        """Update Jenkins public_url and prefix
+            return True when a restart is required, false and a
+            reload via the API is sufficient.
+        """
+        config = hookenv.config()
+        context = {"public_url": config["public-url"]}
+        templating.render(
+            "location-config.xml", paths.LOCATION_CONFIG_FILE, context,
+            owner="jenkins", group="nogroup")
+
+        return self._set_prefix(urlparse(config["public-url"]).path)
+
+    def _set_prefix(self, prefix):
+        """ Set Jenkins to use the given prefix.
+        :param prefix: The prefix Jenkins will be configured to use. If empty
+                       the prefix config is unset.
+        :return: True when an update was made, false otherwise.
+        """
+        if not os.path.exists(paths.DEFAULTS_CONFIG_FILE):
+            hookenv.log("Defaults file {} not found, Jenkins prefix not set.".
+                        format(paths.DEFAULTS_CONFIG_FILE))
+            return False
+
+        prefix_line_base = 'JENKINS_ARGS="$JENKINS_ARGS --prefix='
+        prefix_line = prefix_line_base + prefix + '"'
+        defaults_content = ""
+
+        update = False
+        found = False
+        with open(paths.DEFAULTS_CONFIG_FILE, 'r') as defaults:
+            for line in defaults:
+                if line.startswith(prefix_line_base):
+                    found = True
+                    if not line.startswith(prefix_line):
+                        update = True
+                    continue
+                defaults_content += line
+
+        if prefix:
+            defaults_content += "\n" + prefix_line
+            if not found:
+                update = True
+
+        if update:
+            with open(paths.DEFAULTS_CONFIG_FILE, 'w') as defaults_file:
+                defaults_file.write(defaults_content + "\n")
+            return True
+
+        return False

--- a/lib/charms/layer/jenkins/paths.py
+++ b/lib/charms/layer/jenkins/paths.py
@@ -7,6 +7,9 @@ USERS = os.path.join(HOME, "users")
 PLUGINS = os.path.join(HOME, "plugins")
 SECRETS = os.path.join(HOME, "secrets")
 CONFIG_FILE = os.path.join(HOME, "config.xml")
+LOCATION_CONFIG_FILE =\
+    os.path.join(HOME, "jenkins.model.JenkinsLocationConfiguration.xml")
+DEFAULTS_CONFIG_FILE = "/etc/default/jenkins"
 ADMIN_TOKEN = os.path.join(HOME, ".admin_token")
 ADMIN_PASSWORD = os.path.join(HOME, ".admin_password")
 INITIAL_PASSWORD = os.path.join(SECRETS, "initialAdminPassword")

--- a/lib/charms/layer/jenkins/service.py
+++ b/lib/charms/layer/jenkins/service.py
@@ -2,7 +2,7 @@ import requests
 
 from charmhelpers.core.decorators import retry_on_exception
 
-URL = "http://localhost:8080/"
+from charms.layer.jenkins.api import Api
 
 
 class ServiceUnavailable(Exception):
@@ -18,6 +18,7 @@ class Service(object):
     @retry_on_exception(7, base_delay=5, exc_type=_check_ready_retry)
     def check_ready(self):
         """Build a Jenkins client instance."""
-        response = requests.get(URL)
+        api = Api()
+        response = requests.get(api.url)
         if response.status_code >= 500:
             raise ServiceUnavailable()

--- a/templates/location-config.xml
+++ b/templates/location-config.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jenkins.model.JenkinsLocationConfiguration>
+	<jenkinsUrl>{{public_url}}</jenkinsUrl>
+</jenkins.model.JenkinsLocationConfiguration>

--- a/unit_tests/states.py
+++ b/unit_tests/states.py
@@ -6,7 +6,7 @@ from fixtures import Fixture
 from charmhelpers.core import hookenv
 
 from charms.layer.jenkins import paths
-from charms.layer.jenkins.api import URL
+from charms.layer.jenkins.api import Api
 
 INITIAL_PASSWORD = "initial-pw"
 GENERATED_PASSWORD = "generated-pw"
@@ -30,7 +30,14 @@ class AptInstalledJenkins(State):
         with open(paths.INITIAL_PASSWORD, "w") as fd:
             fd.write(INITIAL_PASSWORD)
 
-        self.fakes.network.get(URL, headers={"X-Jenkins": "2.0.0"})
+        self.fakes.fs.add(paths.DEFAULTS_CONFIG_FILE)
+        os.makedirs('/etc/default')
+        with open(paths.DEFAULTS_CONFIG_FILE, "wb") as fd:
+            fd.write(b"# port for HTTP connector\nHTTP_PORT=8080\n")
+            fd.write(b'JENKINS_ARGS="--httpPort=$HTTP_PORT"')
+
+        api = Api()
+        self.fakes.network.get(api.url, headers={"X-Jenkins": "2.0.0"})
 
 
 class JenkinsConfiguredAdmin(State):

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -1,3 +1,5 @@
+import os
+
 from testtools.matchers import (
     FileContains,
     FileExists,
@@ -33,6 +35,48 @@ class ConfigurationTest(CharmTest):
             paths.CONFIG_FILE,
             FileContains(matcher=Contains("<numExecutors>1</numExecutors>")))
         self.assertEqual({8080}, self.fakes.juju.ports["TCP"])
+
+    def test_set_prefix1(self):
+        # Case #1 - no previous config, no prefix, no change
+        updated = self.configuration._set_prefix("")
+        self.assertFalse(updated)
+
+    def test_set_prefix2(self):
+        # Case #2 - no previous config, a prefix, expected change
+        updated = self.configuration._set_prefix("/jenkins")
+        self.assertTrue(updated)
+
+    def test_set_prefix3(self):
+        # Case #3 - previous config, same prefix, no expected change
+        self.configuration._set_prefix("/jenkins")
+        updated = self.configuration._set_prefix("/jenkins")
+        self.assertFalse(updated)
+
+    def test_set_prefix4(self):
+        # Case #4 - previous config, different prefix, expected change
+        self.configuration._set_prefix("/jenkins")
+        updated = self.configuration._set_prefix("/jenkins-alt")
+        self.assertTrue(updated)
+
+    def test_set_prefix5(self):
+        # Case #5 - previous config, no prefix, expected change
+        self.configuration._set_prefix("/jenkins")
+        updated = self.configuration._set_prefix("")
+        self.assertTrue(updated)
+
+    def test_set_prefix6(self):
+        # Case #6 - no config file, no expected change
+        os.remove(paths.DEFAULTS_CONFIG_FILE)
+        updated = self.configuration._set_prefix("/nothing")
+        self.assertFalse(updated)
+
+    def test_set_url(self):
+        needs_restart = self.configuration.set_url()
+        self.assertFalse(needs_restart)
+        self.assertThat(paths.LOCATION_CONFIG_FILE, HasOwnership(123, 456))
+        self.assertThat(
+            paths.LOCATION_CONFIG_FILE,
+            FileContains(matcher=Contains("<jenkinsUrl></jenkinsUrl>")))
 
     def test_migrate(self):
         """

--- a/unit_tests/test_service.py
+++ b/unit_tests/test_service.py
@@ -2,8 +2,8 @@ import time
 
 from charmtest import CharmTest
 
+from charms.layer.jenkins.api import Api
 from charms.layer.jenkins.service import (
-    URL,
     ServiceUnavailable,
     Service,
 )
@@ -35,12 +35,14 @@ class ServiceTest(CharmTest):
                 context.status_code = 200
             return ""
 
-        self.fakes.network.get(URL, text=callback)
+        api = Api()
+        self.fakes.network.get(api.url, text=callback)
         self.assertIsNone(self.service.check_ready())
 
     def test_check_ready_unavailable(self):
         """
         If the backend keeps returning 5xx, an error is raised.
         """
-        self.fakes.network.get(URL, status_code=500)
+        api = Api()
+        self.fakes.network.get(api.url, status_code=500)
         self.assertRaises(ServiceUnavailable, self.service.check_ready)

--- a/unit_tests/test_users.py
+++ b/unit_tests/test_users.py
@@ -32,7 +32,9 @@ class UsersTest(JenkinsTest):
         """
         If a password is provided, it's used to configure the admin user.
         """
-        self.fakes.juju.config["password"] = "x"
+        config = hookenv.config()
+        config["password"] = "x"
+
         script = UPDATE_PASSWORD_SCRIPT.format(username="admin", password="x")
         self.fakes.jenkins.scripts[script] = ""
 


### PR DESCRIPTION
This change adds the public_url charm configuration option so you can
specify the Jenkins URL and prefix.