### PR TITLE
Configure new nodes to use the JNLP launchers

### DIFF
--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -65,7 +65,16 @@ class Api(object):
                 return
 
             hookenv.log("Adding node '%s' to Jenkins master" % host)
-            client.create_node(host, int(executors), host, labels=labels)
+
+            # See the "Launch slave agent headlessly" section of the Jenkins
+            # wiki page about distributed builds:
+            #
+            # https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds
+            launcher = jenkins.LAUNCHER_JNLP
+
+            client.create_node(
+                host, int(executors), host, labels=labels, launcher=launcher)
+
             if not client.node_exists(host):
                 hookenv.log(
                     "Failed to create node '%s'" % host, level=ERROR)

--- a/unit_tests/fakes.py
+++ b/unit_tests/fakes.py
@@ -6,7 +6,8 @@ from fixtures import (
     MonkeyPatch,
 )
 
-Node = namedtuple("Node", ["host", "executors", "description", "labels"])
+Node = namedtuple(
+    "Node", ["host", "executors", "description", "labels", "launcher"])
 
 
 class FakeJenkins(Fixture):
@@ -33,8 +34,9 @@ class FakeJenkins(Fixture):
                 return True
         return False
 
-    def create_node(self, host, executors, description, labels=()):
-        self.nodes.append(Node(host, executors, description, labels))
+    def create_node(self, host, executors, description, labels=(),
+                    launcher=""):
+        self.nodes.append(Node(host, executors, description, labels, launcher))
 
     def delete_node(self, host):
         for node in self.nodes[:]:

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -66,6 +66,7 @@ class ApiTest(JenkinsTest):
         self.assertEqual(1, node.executors)
         self.assertEqual("slave-0", node.description)
         self.assertEqual(["python"], node.labels)
+        self.assertEqual("hudson.slaves.JNLPLauncher", node.launcher)
 
     def test_add_exists(self):
         """


### PR DESCRIPTION
This fixes #14, a regression highlighted by the slave integration tests,
where starting from Jenkins 2.27 the slave would be rejected at
registration.

See also:

https://issues.jenkins-ci.org/browse/JENKINS-39232