### PR TITLE
Add a jenkins.ready state for use by upper charm layers

### DIFF
--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -97,6 +97,7 @@ def bootstrap_jenkins():
 # change.
 @when("jenkins.bootstrapped", "config.changed.tools")
 def configure_tools():
+    remove_state("jenkins.ready")
     remove_state("jenkins.configured.tools")
     status_set("maintenance", "Installing tools")
     packages = Packages()
@@ -110,6 +111,7 @@ def configure_tools():
 @when_any("config.changed.username", "config.changed.password",
           "config.changed.public-url")
 def configure_admin():
+    remove_state("jenkins.ready")
     remove_state("jenkins.configured.admin")
     api = Api()
 
@@ -145,6 +147,7 @@ def configure_plugins():
         log("External relation detected - skip configuring plugins")
         return
     status_set("maintenance", "Configuring plugins")
+    remove_state("jenkins.ready")
     remove_state("jenkins.configured.plugins")
     plugins = Plugins()
     plugins.install(config("plugins"))
@@ -158,6 +161,7 @@ def configure_plugins():
       "jenkins.configured.plugins")
 def ready():
     status_set("active", "Jenkins is running")
+    set_state("jenkins.ready")
 
 
 @when("website.available")


### PR DESCRIPTION
I'm building a charm that consumes the jenkins-charm layer, and I want
to be able to set a status message when both the Jenkins layer and my layer
are in ready state. I initially tried to use the individual states already
exposed in the jenkins charm layer along with my own state:

    @when('jenkins.configured.tools',
          'jenkins.configured.admin',
          'jenkins.configured.plugins',
          'mylayer.ready')
    def mylayer_ready():
        status_set('active', 'MyJenkinsLayer is Ready')

However, this could lead to either a message of "Jenkins is running" from
the jenkins layer or "MyJenkinsLayer is Ready" from my layer, depending on
which one reacts last.

This commit adds a new state to the jenkins layer that I can use to guarantee
my reaction runs after the jenkins layer:

    @when('jenkins.ready',
          'mylayer.ready')
    def mylayer_ready():
        status_set('active', 'MyJenkinsLayer is Ready')