### PR TITLE
fix #28 slave connection issue due to empty url

### DIFF
--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -37,7 +37,7 @@ class Configuration(object):
         """
         config = hookenv.config()
         url = config["public-url"]
-        context = {"jenkins_url_node": self._get_url_config(url)}
+        context = {"public_url": url}
         templating.render(
             "location-config.xml", paths.LOCATION_CONFIG_FILE, context,
             owner="jenkins", group="nogroup")
@@ -81,7 +81,3 @@ class Configuration(object):
             return True
 
         return False
-
-    def _get_url_config(self, url):
-        """Get Jenkins Url configuration node"""
-        return "<jenkinsUrl>" + url + "</jenkinsUrl>" if url else ""

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -36,12 +36,13 @@ class Configuration(object):
             reload via the API is sufficient.
         """
         config = hookenv.config()
-        context = {"public_url": config["public-url"]}
+        url = config["public-url"]
+        context = {"jenkins_url_node": self._get_url_config(url)}
         templating.render(
             "location-config.xml", paths.LOCATION_CONFIG_FILE, context,
             owner="jenkins", group="nogroup")
 
-        return self._set_prefix(urlparse(config["public-url"]).path)
+        return self._set_prefix(urlparse(url).path)
 
     def _set_prefix(self, prefix):
         """ Set Jenkins to use the given prefix.
@@ -80,3 +81,7 @@ class Configuration(object):
             return True
 
         return False
+
+    def _get_url_config(self, url):
+        """Get Jenkins Url configuration node"""
+        return "<jenkinsUrl>" + url + "</jenkinsUrl>" if url else ""

--- a/templates/location-config.xml
+++ b/templates/location-config.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
-	<jenkinsUrl>{{public_url}}</jenkinsUrl>
+	{{jenkins_url_node}}
 </jenkins.model.JenkinsLocationConfiguration>

--- a/templates/location-config.xml
+++ b/templates/location-config.xml
@@ -1,4 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
-	{{jenkins_url_node}}
+    {% if public_url %}
+        <jenkinsUrl>{{public_url}}</jenkinsUrl>
+    {% endif %}
 </jenkins.model.JenkinsLocationConfiguration>

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -16,6 +16,8 @@ from charms.layer.jenkins.configuration import Configuration
 
 from states import AptInstalledJenkins
 
+from charmhelpers.core import hookenv
+
 
 class ConfigurationTest(CharmTest):
 
@@ -76,7 +78,17 @@ class ConfigurationTest(CharmTest):
         self.assertThat(paths.LOCATION_CONFIG_FILE, HasOwnership(123, 456))
         self.assertThat(
             paths.LOCATION_CONFIG_FILE,
-            FileContains(matcher=Contains("<jenkinsUrl></jenkinsUrl>")))
+            FileContains(
+                matcher=Not(Contains("<jenkinsUrl></jenkinsUrl>"))))
+
+    def test_set_url_not_empty(self):
+        url = "http://jenkins.example.com"
+        hookenv.config()["public-url"] = url
+        self.configuration.set_url()
+        self.assertThat(
+            paths.LOCATION_CONFIG_FILE,
+            FileContains(
+                matcher=Contains("<jenkinsUrl>" + url + "</jenkinsUrl>")))
 
     def test_migrate(self):
         """


### PR DESCRIPTION
the remaining XML node <jenkinsUrl></jenkinsUrl> causes a JNLP invalid argument error

Signed-off-by: Eric Villard <dev@eviweb.fr>