### PR TITLE
[FEATURE] backup/restore jobs directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = lib/charms/layer/jenkins/
+source = actions/,lib/charms/layer/jenkins/
 
 [report]
 fail_under=100

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ You have already seen the password configuration in the "Usage" section. Some ot
 You could also set these config options via a config.yaml on jenkins deploy. For example your config.yaml could look like
 
     jenkins:
-      plugins: htmlpublisher view-job-filters bazaar git 
-      release: trunk 
+      plugins: htmlpublisher view-job-filters bazaar git
+      release: trunk
 
 You would then deploy jenkins with your config such as:
 
     juju deploy --config config.yaml jenkins
- 
+
 ## Extending this charm
 
 If you wish to perform custom configuration of either the master
@@ -77,7 +77,75 @@ These will be executed when the main install, `config-changed` or
 Additional hooks are executed in the context of the install hook
 so may use any variables which are defined in this hook.
 
-# Jenkins Project Information 
+# Backup/Restore Jobs
+
+This charm supports actions that allow you to backup/restore the Jenkins
+jobs directory.
+
+* To backup the current jobs directory, run the `backup-jobs` action:
+
+      juju run-action jenkins/0 backup-jobs [artifacts=False] [online=False]
+
+  This will create a gzipped tar archive of the `/var/lib/jenkins/jobs`
+  directory. The following action parameters are available:
+
+  * **artifacts**: By default, only the `config.yaml` files for each job are
+  included in the archive. If you wish to include all job data, set
+  `artifacts=True`.
+
+  * **online**: By default, the action will stop the jenkins service prior to
+  backing up the jobs directory. If you wish to backup jobs while jenkins is
+  running, set `online=True`.
+
+  Use the UUID from the run-action above to view details about the backup:
+
+      juju show-action-output <action-uuid>
+
+  The output will include a command to retrieve the archive, as well as the
+  sha256 sum so you can verify archive integrity.
+
+* To restore an archived jobs directory, first attach the archive as a charm
+resource. Currently, this charm supports attaching zip and various flavors of
+tar archives (gzipped, bzipped, etc):
+
+      juju attach jenkins jobs=./jobs.tgz
+
+  Once the resource has been attached, run the `restore-jobs` action:
+
+      juju run-action jenkins/0 \
+        restore-jobs [online=False] [overwrite=False] [wipe=False]
+
+  This will extract the attached archive into the `/var/lib/jenkins/jobs`
+  directory. The following action parameters are available:
+
+  * **online**: By default, the action will stop the jenkins service prior to
+  restoring the jobs directory. If you wish to restore jobs while jenkins is
+  running, set `online=True`.
+
+    >Note: Jenkins will not see changes to the jobs directory until it reloads
+    config from disk. This happens automatically when the service is restarted.
+    Running `restore-jobs online=True` will require manual intervention to
+    reload the Jenkins jobs.
+
+  * **overwrite**: By default, only restore files that either do not exist or
+  are newer than files present in the jobs directory. If you wish to overwrite
+  any existing files in the jobs directory, set `overwrite=True`.
+
+    >Note: *overwrite* has no effect when *wipe=True*.
+
+  * **wipe**:  By default, existing data in the jobs directory will be
+  kept (though potentially overwritten if the previously mentioned
+  *overwrite* option is set to *True*). To remove and recreate an empty jobs
+  directory prior to restoration, set `wipe=True`.
+
+  Use the UUID from the run-action above to view details about the restoration:
+
+      juju show-action-output <action-uuid>
+
+  The output will include the name/shasum of the restored archive, as well as
+  any error messages that may have occurred during restoration.
+
+# Jenkins Project Information
 
 - [Jenkins Project Website](http://jenkins-ci.org/)
 - [Jenkins Bug Tracker](https://wiki.jenkins-ci.org/display/JENKINS/Issue+Tracking)

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,44 @@
+backup-jobs:
+  description: Backup the jobs directory as a gzipped tar archive.
+  params:
+    artifacts:
+      type: boolean
+      default: False
+      description: |
+        Include job artifacts in the backup. The default, 'False', will only
+        backup the config.xml files for existing jobs. Setting this to 'True'
+        will include all artifacts from the jobs directory in the archive.
+    online:
+      type: boolean
+      default: False
+      description: |
+        Backup the jobs directory while the jenkins service is running. The
+        default, 'False', will stop the jenkins service, perform the backup,
+        and start the service. When 'True', the jenkins service will remain
+        active during the backup.
+restore-jobs:
+  description: Restore an attached resource archive into the jobs directory.
+  params:
+    online:
+      type: boolean
+      default: False
+      description: |
+        Restore the jobs directory while the jenkins service is running. The
+        default, 'False', will stop the jenkins service, extract the archive
+        to the jobs directory, and start the service. When 'True', the jenkins
+        service will remain active during restoration.
+    overwrite:
+      type: boolean
+      default: False
+      description: |
+        Overwrite existing files in the jobs directory. The default, 'False',
+        will only restore files that either do not exist or are newer
+        than files present in the jobs directory. When 'True', all files in
+        the archive will be restored to the jobs directory.
+    wipe:
+      type: boolean
+      default: False
+      description: |
+        Remove the jobs directory prior to restoration. The default, 'False',
+        will restore files into a pre-existing jobs directory. When 'True',
+        the jobs directory is removed and recreated prior to restoration.

--- a/actions/action_utils.py
+++ b/actions/action_utils.py
@@ -1,0 +1,67 @@
+import sys
+import time
+
+from charmhelpers.core import hookenv, host
+
+
+def _wait_for_jenkins(state, timeout):
+    """
+    Wait for the host jenkins service to settle to a given state.
+
+    :param: string state: Desired state of the jenkins service, 'started' or
+                          'stopped'.
+    :param: int timeout: Seconds to wait for desired state.
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        up = host.service_running('jenkins')
+        if (state is "started" and up) or (state is "stopped" and not up):
+            return True
+        time.sleep(5)
+    return False
+
+
+def fail(msg, output=None):
+    """Fail an action with a message and (optionally) additional output."""
+    if output:
+        hookenv.action_set({'output': output})
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+def fail_if_started(timeout=60):
+    """
+    Fail an action if the jenkins service does not stop in the given time.
+
+    If the service is already stopped, do nothing. If it is running, stop
+    the service. If it does not stop in the given time, fail the action.
+
+    :param: int timeout: Seconds to wait for jenkins to stop.
+    """
+    if host.service_running('jenkins'):
+        host.service_stop('jenkins')
+        if not _wait_for_jenkins(state='stopped', timeout=timeout):
+            error = 'Jenkins did not stop.'
+            detail = ('The action tried to stop the jenkins service, but it '
+                      'did not stop in the given time. The action did not '
+                      'proceed.')
+            fail(error, detail)
+
+
+def fail_if_stopped(timeout=60):
+    """
+    Fail an action if the jenkins service does not start in the given time.
+
+    If the service is already started, do nothing. If it is not running,
+    start the service. If it does not start in the given time, fail the action.
+
+    :param: int timeout: Seconds to wait for jenkins to start.
+    """
+    if not host.service_running('jenkins'):
+        host.service_start('jenkins')
+        if not _wait_for_jenkins(state='started', timeout=timeout):
+            error = 'Jenkins did not start.'
+            detail = ('The action stopped the jenkins service and completed. '
+                      'However, it was unable to start the service after '
+                      'completion. Jenkins is currently stopped.')
+            fail(error, detail)

--- a/actions/backup-jobs
+++ b/actions/backup-jobs
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# This action creates a snapshot (tgz archive) of the jenkins jobs directory.
+
+import action_utils
+import atexit
+import grp
+import os
+import pwd
+import tarfile
+
+from charmhelpers.core import hookenv, host
+from charms.reactive import is_state
+from glob import glob
+from time import strftime
+
+# Fail if jenkins is not ready
+if not is_state('jenkins.configured.admin'):
+    error = 'Jenkins is not ready to perform this action.'
+    detail = 'The jenkins.configured.admin state is not set.'
+    action_utils.fail(error, detail)
+
+# Process action params and setup the archive bits
+artifacts = hookenv.action_get("artifacts")
+file_path = "/home/ubuntu/jobs-{}.tgz".format(strftime("%Y%m%d-%H%M%S"))
+jobs_dir = "/var/lib/jenkins/jobs"
+online = hookenv.action_get("online")
+
+# Stop jenkins if we are not doing an online backup
+if online is False:
+    action_utils.fail_if_started()
+    # we stopped jenkins; ensure it is started when this action exits.
+    atexit.register(action_utils.fail_if_stopped)
+
+# Create the archive
+if artifacts is True:
+    jobs_glob = glob("{}/*".format(jobs_dir))
+else:
+    jobs_glob = glob("{}/*/config.xml".format(jobs_dir))
+
+try:
+    with tarfile.open(file_path, 'w:gz') as archive:
+        for job in jobs_glob:
+            # files in the archive will be relative to jobs_dir
+            archive.add(job, arcname=os.path.relpath(job, jobs_dir))
+except Exception as e:
+    error = 'Error creating {}'.format(file_path)
+    action_utils.fail(error, e)
+
+os.chown(file_path,
+         pwd.getpwnam('ubuntu').pw_uid,
+         grp.getgrnam('ubuntu').gr_gid)
+
+# Set action data
+file_sum = host.file_hash(file_path, hash_type='sha256')
+hookenv.action_set({'output.remotefile': file_path})
+hookenv.action_set({'output.256sum': file_sum})
+hookenv.action_set({'output.fetchcmd': "juju scp {}:{} .".format(
+                    hookenv.local_unit(), file_path)})

--- a/actions/backup-jobs
+++ b/actions/backup-jobs
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# This action creates a snapshot (tgz archive) of the jenkins jobs directory.
-
 import action_utils
 import atexit
 import grp
@@ -14,46 +12,53 @@ from charms.reactive import is_state
 from glob import glob
 from time import strftime
 
-# Fail if jenkins is not ready
-if not is_state('jenkins.configured.admin'):
-    error = 'Jenkins is not ready to perform this action.'
-    detail = 'The jenkins.configured.admin state is not set.'
-    action_utils.fail(error, detail)
 
-# Process action params and setup the archive bits
-artifacts = hookenv.action_get("artifacts")
-file_path = "/home/ubuntu/jobs-{}.tgz".format(strftime("%Y%m%d-%H%M%S"))
-jobs_dir = "/var/lib/jenkins/jobs"
-online = hookenv.action_get("online")
+# This action creates a snapshot (tgz archive) of the jenkins jobs directory.
+def backup():
+    # Fail if jenkins is not ready
+    if not is_state('jenkins.configured.admin'):
+        error = 'Jenkins is not ready to perform this action.'
+        detail = 'The jenkins.configured.admin state is not set.'
+        action_utils.fail(error, detail)
 
-# Stop jenkins if we are not doing an online backup
-if online is False:
-    action_utils.fail_if_started()
-    # we stopped jenkins; ensure it is started when this action exits.
-    atexit.register(action_utils.fail_if_stopped)
+    # Process action params and setup the archive bits
+    artifacts = hookenv.action_get("artifacts")
+    file_path = "/home/ubuntu/jobs-{}.tgz".format(strftime("%Y%m%d-%H%M%S"))
+    jobs_dir = "/var/lib/jenkins/jobs"
+    online = hookenv.action_get("online")
 
-# Create the archive
-if artifacts is True:
-    jobs_glob = glob("{}/*".format(jobs_dir))
-else:
-    jobs_glob = glob("{}/*/config.xml".format(jobs_dir))
+    # Stop jenkins if we are not doing an online backup
+    if online is False:
+        action_utils.fail_if_started()
+        # we stopped jenkins; ensure it is started when this action exits.
+        atexit.register(action_utils.fail_if_stopped)
 
-try:
-    with tarfile.open(file_path, 'w:gz') as archive:
-        for job in jobs_glob:
-            # files in the archive will be relative to jobs_dir
-            archive.add(job, arcname=os.path.relpath(job, jobs_dir))
-except Exception as e:
-    error = 'Error creating {}'.format(file_path)
-    action_utils.fail(error, e)
+    # Create the archive
+    if artifacts is True:
+        jobs_glob = glob("{}/*".format(jobs_dir))
+    else:
+        jobs_glob = glob("{}/*/config.xml".format(jobs_dir))
 
-os.chown(file_path,
-         pwd.getpwnam('ubuntu').pw_uid,
-         grp.getgrnam('ubuntu').gr_gid)
+    try:
+        with tarfile.open(file_path, 'w:gz') as archive:
+            for job in jobs_glob:
+                # files in the archive will be relative to jobs_dir
+                archive.add(job, arcname=os.path.relpath(job, jobs_dir))
+    except Exception as e:
+        error = 'Error creating {}'.format(file_path)
+        action_utils.fail(error, e)
 
-# Set action data
-file_sum = host.file_hash(file_path, hash_type='sha256')
-hookenv.action_set({'output.remotefile': file_path})
-hookenv.action_set({'output.256sum': file_sum})
-hookenv.action_set({'output.fetchcmd': "juju scp {}:{} .".format(
-                    hookenv.local_unit(), file_path)})
+    os.chown(file_path,
+             pwd.getpwnam('ubuntu').pw_uid,
+             grp.getgrnam('ubuntu').gr_gid)
+
+    # Set action data
+    file_sum = host.file_hash(file_path, hash_type='sha256')
+    hookenv.action_set({'output.remotefile': file_path})
+    hookenv.action_set({'output.256sum': file_sum})
+    hookenv.action_set({'output.fetchcmd': "juju scp {}:{} .".format(
+                        hookenv.local_unit(), file_path)})
+
+
+if __name__ == '__main__':
+    backup()

--- a/actions/restore-jobs
+++ b/actions/restore-jobs
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# This action expands a resource to the jenkins jobs directory.
-
 import action_utils
 import atexit
 import distutils.dir_util
@@ -12,52 +10,59 @@ from charmhelpers.payload import archive
 from charms.reactive import is_state
 from shutil import rmtree
 
-# Fail if jenkins is not ready
-if not is_state('jenkins.configured.admin'):
-    error = 'Jenkins is not ready to perform this action.'
-    detail = 'The jenkins.configured.admin state is not set.'
-    action_utils.fail(error, detail)
 
-# Process action params and set vars for later user
-file_path = hookenv.resource_get("jobs")
-jobs_dir = "/var/lib/jenkins/jobs"
-online = hookenv.action_get("online")
-overwrite = hookenv.action_get("overwrite")
-tmp_dir = tempfile.TemporaryDirectory()
-wipe = hookenv.action_get("wipe")
+# This action expands a resource to the jenkins jobs directory.
+def restore():
+    # Fail if jenkins is not ready
+    if not is_state('jenkins.configured.admin'):
+        error = 'Jenkins is not ready to perform this action.'
+        detail = 'The jenkins.configured.admin state is not set.'
+        action_utils.fail(error, detail)
 
-# Extract the archive to a temp dir, failing fast if we encounter problems
-try:
-    archive.extract(file_path, tmp_dir.name)
-except Exception as e:
-    error = 'Error extracting {}. Jobs directory is unchanged'.format(file_path)
-    action_utils.fail(error, e)
+    # Process action params and set vars for later user
+    file_path = hookenv.resource_get("jobs")
+    jobs_dir = "/var/lib/jenkins/jobs"
+    online = hookenv.action_get("online")
+    overwrite = hookenv.action_get("overwrite")
+    tmp_dir = tempfile.TemporaryDirectory()
+    wipe = hookenv.action_get("wipe")
 
-# Stop jenkins if we are not doing an online restore
-if online is False:
-    action_utils.fail_if_started()
-    # we stopped jenkins; ensure it is started when this action exits.
-    atexit.register(action_utils.fail_if_stopped)
+    # Extract the archive to a temp dir, failing fast if we encounter problems
+    try:
+        archive.extract(file_path, tmp_dir.name)
+    except Exception as e:
+        error = 'Error extracting {}. Jobs directory is unchanged'.format(file_path)
+        action_utils.fail(error, e)
 
-# Wipe/recreate the current jobs dir if requested
-if wipe is True:
-    rmtree(jobs_dir)
-    host.mkdir(jobs_dir, owner='jenkins', group='jenkins', perms=0o755)
+    # Stop jenkins if we are not doing an online restore
+    if online is False:
+        action_utils.fail_if_started()
+        # we stopped jenkins; ensure it is started when this action exits.
+        atexit.register(action_utils.fail_if_stopped)
 
-# Copy bits to the jobs directory. Adjust update param as needed (an update
-# is the opposite of an overwrite).
-if overwrite is True:
-    distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=False)
-else:
-    distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=True)
+    # Wipe/recreate the current jobs dir if requested
+    if wipe is True:
+        rmtree(jobs_dir)
+        host.mkdir(jobs_dir, owner='jenkins', group='jenkins', perms=0o755)
 
-# Make sure our jobs dir is owned by jenkins
-host.chownr(jobs_dir, owner='jenkins', group='jenkins')
+    # Copy bits to the jobs directory. Adjust update param as needed (an update
+    # is the opposite of an overwrite).
+    if overwrite is True:
+        distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=False)
+    else:
+        distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=True)
 
-# Temp dir should clean itself up when we exit, but be explicit just in case
-tmp_dir.cleanup()
+    # Make sure our jobs dir is owned by jenkins
+    host.chownr(jobs_dir, owner='jenkins', group='jenkins')
 
-# Set action data
-file_sum = host.file_hash(file_path, hash_type='sha256')
-hookenv.action_set({'output.file': file_path})
-hookenv.action_set({'output.256sum': file_sum})
+    # Temp dir should clean itself up when we exit, but be explicit just in case
+    tmp_dir.cleanup()
+
+    # Set action data
+    file_sum = host.file_hash(file_path, hash_type='sha256')
+    hookenv.action_set({'output.file': file_path})
+    hookenv.action_set({'output.256sum': file_sum})
+
+
+if __name__ == '__main__':
+    restore()

--- a/actions/restore-jobs
+++ b/actions/restore-jobs
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# This action expands a resource to the jenkins jobs directory.
+
+import action_utils
+import atexit
+import distutils.dir_util
+import tempfile
+
+from charmhelpers.core import hookenv, host
+from charmhelpers.payload import archive
+from charms.reactive import is_state
+from shutil import rmtree
+
+# Fail if jenkins is not ready
+if not is_state('jenkins.configured.admin'):
+    error = 'Jenkins is not ready to perform this action.'
+    detail = 'The jenkins.configured.admin state is not set.'
+    action_utils.fail(error, detail)
+
+# Process action params and set vars for later user
+file_path = hookenv.resource_get("jobs")
+jobs_dir = "/var/lib/jenkins/jobs"
+online = hookenv.action_get("online")
+overwrite = hookenv.action_get("overwrite")
+tmp_dir = tempfile.TemporaryDirectory()
+wipe = hookenv.action_get("wipe")
+
+# Extract the archive to a temp dir, failing fast if we encounter problems
+try:
+    archive.extract(file_path, tmp_dir.name)
+except Exception as e:
+    error = 'Error extracting {}. Jobs directory is unchanged'.format(file_path)
+    action_utils.fail(error, e)
+
+# Stop jenkins if we are not doing an online restore
+if online is False:
+    action_utils.fail_if_started()
+    # we stopped jenkins; ensure it is started when this action exits.
+    atexit.register(action_utils.fail_if_stopped)
+
+# Wipe/recreate the current jobs dir if requested
+if wipe is True:
+    rmtree(jobs_dir)
+    host.mkdir(jobs_dir, owner='jenkins', group='jenkins', perms=0o755)
+
+# Copy bits to the jobs directory. Adjust update param as needed (an update
+# is the opposite of an overwrite).
+if overwrite is True:
+    distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=False)
+else:
+    distutils.dir_util.copy_tree(src=tmp_dir.name, dst=jobs_dir, update=True)
+
+# Make sure our jobs dir is owned by jenkins
+host.chownr(jobs_dir, owner='jenkins', group='jenkins')
+
+# Temp dir should clean itself up when we exit, but be explicit just in case
+tmp_dir.cleanup()
+
+# Set action data
+file_sum = host.file_hash(file_path, hash_type='sha256')
+hookenv.action_set({'output.file': file_path})
+hookenv.action_set({'output.256sum': file_sum})

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,13 +4,13 @@ maintainer: Free Ekanayaka <free.ekanayaka@canonical.com>
 description: |
   Jenkins is an extendable open source continuous
   integration server that monitors executions of
-  repeated jobs. The focus of Jenkins is the 
-  building/testing of software project continuously, 
+  repeated jobs. The focus of Jenkins is the
+  building/testing of software project continuously,
   and monitoring executions of externally-run jobs.
   More information at http://jenkins-ci.org/.
-  
+
   This charm provides the Jenkins master service,
-  and when paired with the jenkins-slave charm 
+  and when paired with the jenkins-slave charm
   provides an easy way to deploy Jenkins on Ubuntu
   server, and scale out Jenkins slaves.
 tags:
@@ -36,6 +36,14 @@ requires:
   zuul:
     interface: zuul
     optional: true
+resources:
+  jobs:
+    type: file
+    filename: jobs.tgz
+    description: |
+      A tar or zip archive containing Jenkins jobs files to be expanded
+      to the /var/lib/jenkins/jobs directory. This resource is required to
+      use the 'restore-jobs' action.
 storage:
   jenkins:
     type: filesystem

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -171,3 +171,26 @@ class BasicDeploymentTest(DeploymentTest):
             self.assertIn("greenballs", plugins, "Failed to locate greenballs")
 
         assert_plugins()
+
+    def test_20_backup_jobs(self):
+        """
+        Validate we can backup the jobs directory by running the backup-jobs
+        action.
+        """
+        uuid = self.spec.jenkins.run_action('backup-jobs')
+        result = self.spec.deployment.action_fetch(uuid, full_output=True)
+        # action status=completed on success
+        if (result['status'] != "completed"):
+            self.fail('Jenkins backup-jobs action failed: %s' % result)
+
+    def test_20_restore_jobs(self):
+        """
+        Validate restore-jobs fails as expected when the jobs resource is not
+        a valid archive (which is true since we have not attached a resource).
+        """
+        uuid = self.spec.jenkins.run_action('restore-jobs')
+        result = self.spec.deployment.action_fetch(uuid, full_output=True)
+        # Our action should fail with a 'no handler' message
+        self.assertIn("No handler for archive",
+                      result['results']['output'],
+                      "Jenkins restore-jobs action did not fail as expected")

--- a/unit_tests/test_action_utils.py
+++ b/unit_tests/test_action_utils.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest import mock
+from actions import action_utils
+
+
+class TestActionUtils(unittest.TestCase):
+
+    @mock.patch('actions.action_utils.hookenv.action_set')
+    @mock.patch('actions.action_utils.hookenv.action_fail')
+    @mock.patch('actions.action_utils.sys.exit')
+    def test_fail(self, mock_sys_exit, mock_action_fail, mock_action_set):
+        """
+        Verify we fail cleanly and make expected action_* calls.
+        """
+        error = 'test'
+        details = 'details'
+        self.assertEqual(None, action_utils.fail(msg=error, output=details))
+        mock_action_set.assert_called_once_with({'output': details})
+        mock_action_fail.assert_called_once_with(error)
+
+    @mock.patch('actions.action_utils.host.service_running')
+    @mock.patch('actions.action_utils.host.service_stop')
+    @mock.patch('actions.action_utils._wait_for_jenkins')
+    @mock.patch('actions.action_utils.fail')
+    def test_fail_if_started(self, mock_fail, mock_wait, mock_stop,
+                             mock_running):
+        """
+        Test our failure path if we cannot stop jenkins.
+        """
+        # test when jenkins is already stopped
+        mock_running.return_value = False
+        self.assertEqual(None, action_utils.fail_if_started(5))
+        mock_fail.assert_not_called()
+
+        # test when jenkins is running and we succesfully stop it
+        mock_running.return_value = True
+        mock_wait.return_value = True
+        self.assertEqual(None, action_utils.fail_if_started(5))
+        mock_fail.assert_not_called()
+
+        # test when jenkins is running and we do not stop it
+        mock_running.return_value = True
+        mock_wait.return_value = False
+        self.assertEqual(None, action_utils.fail_if_started(5))
+        args, kwargs = mock_fail.call_args
+        mock_fail.assert_called_once_with(*args)
+
+    @mock.patch('actions.action_utils.host.service_running')
+    @mock.patch('actions.action_utils.host.service_start')
+    @mock.patch('actions.action_utils._wait_for_jenkins')
+    @mock.patch('actions.action_utils.fail')
+    def test_fail_if_stopped(self, mock_fail, mock_wait, mock_start,
+                             mock_running):
+        """
+        Test our failure path if we cannot start jenkins.
+        """
+        # test when jenkins is already started
+        mock_running.return_value = True
+        self.assertEqual(None, action_utils.fail_if_stopped(5))
+        mock_fail.assert_not_called()
+
+        # test when jenkins is stopped and we succesfully start it
+        mock_running.return_value = False
+        mock_wait.return_value = True
+        self.assertEqual(None, action_utils.fail_if_stopped(5))
+        mock_fail.assert_not_called()
+
+        # test when jenkins is stopped and we do not start it
+        mock_running.return_value = False
+        mock_wait.return_value = False
+        self.assertEqual(None, action_utils.fail_if_stopped(5))
+        args, kwargs = mock_fail.call_args
+        mock_fail.assert_called_once_with(*args)
+
+    @mock.patch('actions.action_utils.host.service_running')
+    def test_wait(self, mock_running):
+        """
+        Test our timer.
+        """
+        # test when jenkins is running
+        mock_running.return_value = True
+        self.assertTrue(action_utils._wait_for_jenkins('started', 5))
+        self.assertFalse(action_utils._wait_for_jenkins('stopped', 5))
+
+        # test when jenkins is stopped
+        mock_running.return_value = False
+        self.assertTrue(action_utils._wait_for_jenkins('stopped', 5))
+        self.assertFalse(action_utils._wait_for_jenkins('started', 5))


### PR DESCRIPTION
Include actions that allow a user to backup and restore the jenkins job dir.  Usage details can be found in the additions to README.md, but the basics are:

```bash
## backup
$ juju run-action jenkins/0 backup-jobs
...
fetchcmd = juju scp jenkins/0:<path> .
...
$ juju scp jenkins/0:/home/ubuntu/jobs-x.tgz .

## restore
$ juju attach jenkins jobs=./jobs-x.tgz
$ juju run-action jenkins/0 restore-jobs
```

One potential point of contention may be the requirement for users to attach a resource to be used during `restore-jobs`.  I considered having a url parameter that the action would fetch.  However, given the multitude of url patterns and problems accessing a random url in a restricted network deployment, I decided that attaching a local file would give the best UX.

If merged, this means that all future `charm release jenkins` activity would need to include a jobs resource, e.g.:

```bash
## create a dummy jobs resource placeholder
$ touch /tmp/jobs.tgz
$ charm push <dir> <cs> --resource jobs=/tmp/jobs.tgz

## all subsequent releases can use 'jobs-0', no need to touch/attach new placeholders
$ charm release <cs> --resource jobs-0
```

The above is simply attaching a 0-byte resource to the charm, which will be handled correctly by the restore action (i.e., it will fail gracefully if anyone attempts to restore jobs using the default resource).

Note, there may very well be a jenkins plugin that already provides this functionality, but from my limited research, it seems most online tutorials walk a user through backing up / restoring the jobs directory manually.  This PR, then, simply action-ifies that process.  It's also handy to backup/restore without needing to click through the web interface.