### PR TITLE
Use a specific (configurable) port for slave JNLP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Slaves will attempt to connect via JNLP on port 48484 by default. This is config
 
     juju set jenkins jnlp-port=12345
 
+If you want the previously-default behaviour of a random TCP port, you can set this to -1:
+
+    juju set jenkins jnlp-port=-1
+
+Or if you want to disable the feature entirely, set it to 0:
+
+    juju set jenkins jnlp-port=0
+
 The default password for the 'admin' account will be auto-generated.
 
 You can set it using:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ If you want to run jobs on separate nodes you will also need to deploy the jenki
     juju deploy -n 5 jenkins-slave
     juju add-relation jenkins jenkins-slave
 
+Slaves will attempt to connect via JNLP on port 48484 by default. This is configurable, e.g.:
+
+    juju set jenkins jnlp-port=12345
+
 The default password for the 'admin' account will be auto-generated.
 
 You can set it using:

--- a/config.yaml
+++ b/config.yaml
@@ -54,3 +54,8 @@ options:
     description: |
       Public url of Jenkins frontend, including the hostname and prefix. This
       is used by Jenkins whenever generating full links.
+  jnlp-port:
+    type: int
+    default: 48484
+    description: |
+      TCP port on which to listen for incoming connections from slaves

--- a/config.yaml
+++ b/config.yaml
@@ -58,4 +58,5 @@ options:
     type: int
     default: 48484
     description: |
-      TCP port on which to listen for incoming connections from slaves
+      TCP port on which to listen for incoming connections from slaves.
+      Set to -1 for a random port, or to 0 to disable JNLP entirely.

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -21,12 +21,20 @@ class Configuration(object):
             "master_executors": config["master-executors"],
             "jnlp_port": config["jnlp-port"],
         }
+
+        # check for sane values, default to, uhh, the default
+        if not -1 <= config["jnlp-port"] <= 65535:
+            config["jnlp-port"] = 48484
+
+        # if we're using a set JNLP port, open it
+        if config["jnlp-port"] > 0:
+            hookenv.open_port(config["jnlp-port"])
+
         templating.render(
             "jenkins-config.xml", paths.CONFIG_FILE, context,
             owner="jenkins", group="nogroup")
 
         hookenv.open_port(PORT)
-        hookenv.open_port(config["jnlp-port"])
 
     def migrate(self):
         """Drop the legacy boostrap flag file."""

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -25,22 +25,22 @@ class Configuration(object):
             hookenv.log(err)
             hookenv.status_set("blocked", err)
             return False
-        else:
-            context = {
-                "master_executors": config["master-executors"],
-                "jnlp_port": config["jnlp-port"]}
 
-            templating.render(
-                "jenkins-config.xml", paths.CONFIG_FILE, context,
-                owner="jenkins", group="nogroup")
+        context = {
+            "master_executors": config["master-executors"],
+            "jnlp_port": config["jnlp-port"]}
 
-            hookenv.open_port(PORT)
+        templating.render(
+            "jenkins-config.xml", paths.CONFIG_FILE, context,
+            owner="jenkins", group="nogroup")
 
-            # if we're using a set JNLP port, open it
-            if config["jnlp-port"] > 0:
-                hookenv.open_port(config["jnlp-port"])
+        hookenv.open_port(PORT)
 
-            return True
+        # if we're using a set JNLP port, open it
+        if config["jnlp-port"] > 0:
+            hookenv.open_port(config["jnlp-port"])
+
+        return True
 
     def migrate(self):
         """Drop the legacy boostrap flag file."""

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -26,7 +26,7 @@ class Configuration(object):
             owner="jenkins", group="nogroup")
 
         hookenv.open_port(PORT)
-        hookenv.open_port(config["jnlp_port"])
+        hookenv.open_port(config["jnlp-port"])
 
     def migrate(self):
         """Drop the legacy boostrap flag file."""

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -17,12 +17,16 @@ class Configuration(object):
         hookenv.log("Bootstrapping initial Jenkins configuration")
 
         config = hookenv.config()
-        context = {"master_executors": config["master-executors"]}
+        context = {
+            "master_executors": config["master-executors"],
+            "jnlp_port": config["jnlp-port"],
+        }
         templating.render(
             "jenkins-config.xml", paths.CONFIG_FILE, context,
             owner="jenkins", group="nogroup")
 
         hookenv.open_port(PORT)
+        hookenv.open_port(config["jnlp_port"])
 
     def migrate(self):
         """Drop the legacy boostrap flag file."""

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -17,18 +17,18 @@ class Configuration(object):
         hookenv.log("Bootstrapping initial Jenkins configuration")
 
         config = hookenv.config()
-        context = {
-            "master_executors": config["master-executors"],
-            "jnlp_port": config["jnlp-port"],
-        }
 
-        # check for sane values, default to, uhh, the default
-        if not -1 <= config["jnlp-port"] <= 65535:
+        # check for sane port values, fall back to the default
+        if not -1 <= config["jnlp-port"] <= 65535: # pragma: no cover
             config["jnlp-port"] = 48484
 
         # if we're using a set JNLP port, open it
         if config["jnlp-port"] > 0:
             hookenv.open_port(config["jnlp-port"])
+
+        context = {
+            "master_executors": config["master-executors"],
+            "jnlp_port": config["jnlp-port"]}
 
         templating.render(
             "jenkins-config.xml", paths.CONFIG_FILE, context,

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -89,8 +89,8 @@ def bootstrap_jenkins():
     service = Service()
     service.check_ready()
     configuration = Configuration()
-    configuration.bootstrap()
-    set_state("jenkins.bootstrapped")
+    if configuration.bootstrap():
+        set_state("jenkins.bootstrapped")
 
 
 # Called once we're bootstrapped and every time the configured tools

--- a/templates/jenkins-config.xml
+++ b/templates/jenkins-config.xml
@@ -9,4 +9,5 @@
     <disableSignup>true</disableSignup>
     <enableCaptcha>false</enableCaptcha>
   </securityRealm>
+  <slaveAgentPort>{{jnlp_port}}</slaveAgentPort>
 </hudson>

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -36,7 +36,7 @@ class ConfigurationTest(CharmTest):
         self.assertThat(
             paths.CONFIG_FILE,
             FileContains(matcher=Contains("<numExecutors>1</numExecutors>")))
-        self.assertEqual({8080}, self.fakes.juju.ports["TCP"])
+        self.assertEqual({8080, 48484}, self.fakes.juju.ports["TCP"])
 
     def test_set_prefix1(self):
         # Case #1 - no previous config, no prefix, no change

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -36,6 +36,11 @@ class ConfigurationTest(CharmTest):
         self.assertThat(
             paths.CONFIG_FILE,
             FileContains(matcher=Contains("<numExecutors>1</numExecutors>")))
+        self.assertThat(
+            paths.CONFIG_FILE,
+            FileContains(
+                matcher=Contains("<slaveAgentPort>48484</slaveAgentPort>"))
+            )
         self.assertEqual({8080, 48484}, self.fakes.juju.ports["TCP"])
 
     def test_set_prefix1(self):
@@ -71,6 +76,13 @@ class ConfigurationTest(CharmTest):
         os.remove(paths.DEFAULTS_CONFIG_FILE)
         updated = self.configuration._set_prefix("/nothing")
         self.assertFalse(updated)
+
+    def test_bad_jnlp_port(self):
+        # bootstrap should fail and return False if we set an invalid port
+        bad_port = 99999
+        hookenv.config()["jnlp-port"] = bad_port
+        bootstrap = self.configuration.bootstrap()
+        self.assertFalse(bootstrap)
 
     def test_set_url(self):
         needs_restart = self.configuration.set_url()


### PR DESCRIPTION
Currently Jenkins defaults to setting up slaves to communicate on a random port.

If slaves are deployed behind default-deny firewalls, the administrator will have no way to know which port must be opened to grant access.

This PR changes that behaviour to use a specific, configurable port instead (48484 by default).