### PR TITLE
A few error handling fixes

### DIFF
--- a/lib/charms/layer/jenkins/credentials.py
+++ b/lib/charms/layer/jenkins/credentials.py
@@ -28,21 +28,21 @@ class Credentials(object):
 
         password = hookenv.config()["password"]
         if not password:
-            password = hookenv.config()["_generated-password"]
+            with open(paths.ADMIN_PASSWORD, 'r') as f:
+                password = f.read().strip()
         return password
 
     def token(self, value=None):
         """Get or set the admin token from/to the local state."""
-        config = hookenv.config()
         if value is not None:
-            config["_api-token"] = value
-            # Save the token to a file as well. It's not used directly by
-            # this charm but it's convenient for integration with
-            # third-party tools.
+            # Save the token to a file
             host.write_file(
                 paths.ADMIN_TOKEN, value.encode("utf-8"), owner="root",
                 group="root", perms=0o0600)
-        return config.get("_api-token")
+        if not os.path.exists(paths.ADMIN_TOKEN):
+            return None
+        with open(paths.ADMIN_TOKEN, 'r') as f:
+            return f.read().strip()
 
     def _initial_password(self):
         """Return the initial admin password."""

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -28,7 +28,7 @@ class Plugins(object):
         try:
             installed_plugins = self._install_plugins(plugins)
         except:
-            hookenv.log("Can't download plugin: {}".format(url))
+            hookenv.log("Plugin installation failed, check logs for details")
             host.service_start("jenkins")  # Make sure we don't leave jenkins down
             raise
 

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -19,14 +19,19 @@ class Plugins(object):
         plugins = plugins.split()
         hookenv.log("Stopping jenkins for plugin update(s)")
         host.service_stop("jenkins")
-
         hookenv.log("Installing plugins (%s)" % " ".join(plugins))
 
         host.mkdir(
             paths.PLUGINS, owner="jenkins", group="jenkins", perms=0o0755)
 
         existing_plugins = set(glob.glob("%s/*.hpi" % paths.PLUGINS))
-        installed_plugins = self._install_plugins(plugins)
+        try:
+            installed_plugins = self._install_plugins(plugins)
+        except:
+            hookenv.log("Can't download plugin: {}".format(url))
+            host.service_start("jenkins")  # Make sure we don't leave jenkins down
+            raise
+
         unlisted_plugins = existing_plugins - installed_plugins
         if unlisted_plugins:
             if hookenv.config()["remove-unlisted-plugins"] == "yes":

--- a/lib/charms/layer/jenkins/users.py
+++ b/lib/charms/layer/jenkins/users.py
@@ -37,8 +37,17 @@ class Users(object):
 
     def _admin_data(self):
         """Get a named tuple holding configuration data for the admin user."""
-        creds = Credentials()
-        return _User(creds.username(), creds.password())
+        config = hookenv.config()
+        username = config["username"]
+        password = config["password"]
+
+        if not password:
+            password = host.pwgen(length=15)
+            # Save the password to the local state, so it can be accessed
+            # by the Credentials class.
+            config["_generated-password"] = password
+
+        return _User(username, password)
 
 
 _User = namedtuple("User", ["username", "password"])

--- a/lib/charms/layer/jenkins/users.py
+++ b/lib/charms/layer/jenkins/users.py
@@ -7,7 +7,6 @@ from charmhelpers.core import host
 
 from charms.layer.jenkins import paths
 from charms.layer.jenkins.api import Api
-from charms.layer.jenkins.credentials import Credentials
 
 
 class Users(object):

--- a/lib/charms/layer/jenkins/users.py
+++ b/lib/charms/layer/jenkins/users.py
@@ -7,6 +7,7 @@ from charmhelpers.core import host
 
 from charms.layer.jenkins import paths
 from charms.layer.jenkins.api import Api
+from charms.layer.jenkins.credentials import Credentials
 
 
 class Users(object):
@@ -32,21 +33,12 @@ class Users(object):
             # presenting the setup wizard.
             host.write_file(
                 paths.LAST_EXEC, "{}\n".format(api.version()).encode("utf-8"),
-                owner="jenkins", group="nogroup")
+                owner="jenkins", group="nogroup", perms=0o0600)
 
     def _admin_data(self):
         """Get a named tuple holding configuration data for the admin user."""
-        config = hookenv.config()
-        username = config["username"]
-        password = config["password"]
-
-        if not password:
-            password = host.pwgen(length=15)
-            # Save the password to the local state, so it can be accessed
-            # by the Credentials class.
-            config["_generated-password"] = password
-
-        return _User(username, password)
+        creds = Credentials()
+        return _User(creds.username(), creds.password())
 
 
 _User = namedtuple("User", ["username", "password"])

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -20,7 +20,6 @@ from charms.reactive import (
     when,
     when_not,
     when_any,
-    only_once,
     set_state,
     remove_state,
 )
@@ -82,7 +81,7 @@ def install_jenkins():
 # perform any configuration yet. We'll not touch config.xml ever again,
 # since from this point it should be managed by the user (or by some
 # subordinate charm via the 'jenkins-extension' interface).
-@only_once()
+@when_not("jenkins.bootstrapped")
 @when("apt.installed.jenkins")
 def bootstrap_jenkins():
     status_set("maintenance", "Bootstrapping Jenkins configuration")

--- a/unit_tests/test_credentials.py
+++ b/unit_tests/test_credentials.py
@@ -79,7 +79,6 @@ class CredentialsTest(CharmTest):
         """
         self.useFixture(JenkinsConfiguredAdmin(self.fakes))
         self.assertEqual("abc", self.credentials.token("abc"))
-        self.assertEqual("abc", hookenv.config()["_api-token"])
         self.assertEqual("abc", self.credentials.token())
         self.assertThat(paths.ADMIN_TOKEN, FileContains("abc"))
         self.assertThat(paths.ADMIN_TOKEN, HasOwnership(0, 0))

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -91,3 +91,18 @@ class PluginsTest(CharmTest):
         self.plugins.install("plugin")
         commands = [proc.args[0] for proc in self.fakes.processes.procs]
         self.assertNotIn("wget", commands)
+
+    def test_install_bad_plugin(self):
+        """
+        If plugin can't be downloaded we expect error message in the logs
+        """
+        def broken_download(*args, **kwargs):
+            raise Exception("error")
+
+        self.plugins._install_plugin = broken_download
+        self.fakes.juju.config["remove-unlisted-plugins"] = "yes"
+        plugin_path = os.path.join(paths.PLUGINS, "bad_plugin.hpi")
+        with open(plugin_path, "w"):
+            pass
+        self.assertRaises(Exception,
+                          self.plugins.install, "bad_plugin")


### PR DESCRIPTION
This change improves error handling and fixes a few bug I hit during testing
* improve password handling to avoid relying on config variables which sometimes disappear
* improve plugin installation error handling
* replace unreliable @only_once decorator with @when_not