### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .unit-state.db
 *__pycache__
 *.pyc
+*.swp
 lib/charms/__init__.py
 lib/charms/layer/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+test:
+	tox
+
+lxc-test:
+	@$(check-lxc)
+	tox
+
+lxc-setup:
+	@$(check-lxc)
+	sudo apt-get update
+	sudo apt-get install -y tox
+
+run-lxc-test:
+	./scripts/lxc-test
+
+################################################################################
+
+define check-lxc
+    if ! sudo grep -q lxc /proc/1/environ 2> /dev/null; then \
+		echo "Not running inside an LXC; aborting."; exit 1; \
+	fi
+endef

--- a/scripts/lxc-test
+++ b/scripts/lxc-test
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Script to run lint and test suite inside LXC.
+
+if [[ -z "${SQUID_PROXY}" ]]; then
+    PROXY_COMMAND=""
+else
+    PROXY_COMMAND="https_proxy=${SQUID_PROXY} http_proxy=${SQUID_PROXY}"
+    if [[ -n "${NO_PROXY}" ]]; then
+        PROXY_COMMAND="${PROXY_COMMAND} no_proxy=${NO_PROXY}"
+    fi
+fi
+
+set -eu
+
+CONTAINER_NAME=${JOB_BASE_NAME:-jenkins-charm}
+
+function log_info() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: $1"
+}
+
+function lxc_run() {
+    cmd=$1
+    log_info "Running command \"${cmd}\" in container \"${CONTAINER_NAME}\" as root"
+    lxc exec ${CONTAINER_NAME} -- bash -c "${cmd}"
+}
+
+function lxc_run_as_ubuntu() {
+    cmd=$1
+    log_info "Running command \"${cmd}\" in container \"${CONTAINER_NAME}\" as ubuntu"
+    lxc exec ${CONTAINER_NAME} -- sudo -u ubuntu -i ${cmd}
+}
+
+function recreate_lxc() {
+    set +e
+    log_info "Checking if container exists"
+    lxc list | grep ${CONTAINER_NAME}
+    if [ $? -eq 0 ]; then
+        log_info "Found old container, deleting"
+        lxc delete --force ${CONTAINER_NAME}
+    fi
+    set -e
+    lxc launch ubuntu:16.04 ${CONTAINER_NAME}
+    # We shouldn't need to just wait here, but there doesn't appear to be an
+    # lxc wait command.
+    sleep 20
+    # Install packages.
+    lxc_run "apt update"
+    lxc_run "apt install -y make"
+    lxc_run_as_ubuntu "mkdir /home/ubuntu/jenkins-charm"
+    # Copy the source (current directory) into LXC
+    tar cf - . | lxc exec ${CONTAINER_NAME} -- tar xvf - -C /home/ubuntu/jenkins-charm
+    lxc_run "chown -R ubuntu:ubuntu /home/ubuntu/jenkins-charm"
+    # Run the code setup.
+    lxc_run_as_ubuntu "${PROXY_COMMAND} make -C /home/ubuntu/jenkins-charm lxc-setup"
+}
+
+log_info "Recreating container \"${CONTAINER_NAME}\""
+recreate_lxc
+
+# Provide a visual break so it's more obvious set up has finished and you're
+# now looking at output you care about
+log_info ""
+log_info "--------------------------------------------"
+log_info "Set up complete, about to run lint and tests"
+log_info "--------------------------------------------"
+log_info ""
+
+lxc_run_as_ubuntu "make -C /home/ubuntu/jenkins-charm lxc-test"
+
+log_info "Cleaning up"
+lxc delete --force ${CONTAINER_NAME}

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -171,8 +171,12 @@ class ApiTest(JenkinsTest):
         Verify the url always ends in a / and has the expected prefix
         """
         config = hookenv.config()
-        config["public-url"] = ""
-        self.assertEqual(self.api.url, 'http://localhost:8080/')
+        orig_public_url = config["public-url"]
+        try:
+            config["public-url"] = ""
+            self.assertEqual(self.api.url, 'http://localhost:8080/')
 
-        config["public-url"] = "http://here:8080/jenkins"
-        self.assertEqual(self.api.url, 'http://localhost:8080/jenkins/')
+            config["public-url"] = "http://here:8080/jenkins"
+            self.assertEqual(self.api.url, 'http://localhost:8080/jenkins/')
+        finally:
+            config["public-url"] = orig_public_url

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -100,12 +100,16 @@ class ConfigurationTest(CharmTest):
 
     def test_set_url_not_empty(self):
         url = "http://jenkins.example.com"
-        hookenv.config()["public-url"] = url
-        self.configuration.set_url()
-        self.assertThat(
-            paths.LOCATION_CONFIG_FILE,
-            FileContains(
-                matcher=Contains("<jenkinsUrl>" + url + "</jenkinsUrl>")))
+        orig_public_url = hookenv.config()["public-url"]
+        try:
+            hookenv.config()["public-url"] = url
+            self.configuration.set_url()
+            self.assertThat(
+                paths.LOCATION_CONFIG_FILE,
+                FileContains(
+                    matcher=Contains("<jenkinsUrl>" + url + "</jenkinsUrl>")))
+        finally:
+            hookenv.config()["public-url"] = orig_public_url
 
     def test_migrate(self):
         """

--- a/unit_tests/test_configuration.py
+++ b/unit_tests/test_configuration.py
@@ -78,11 +78,16 @@ class ConfigurationTest(CharmTest):
         self.assertFalse(updated)
 
     def test_bad_jnlp_port(self):
-        # bootstrap should fail and return False if we set an invalid port
-        bad_port = 99999
-        hookenv.config()["jnlp-port"] = bad_port
-        bootstrap = self.configuration.bootstrap()
-        self.assertFalse(bootstrap)
+        # Bootstrap should fail and return False if we set an invalid port
+        orig_port = hookenv.config()["jnlp-port"]
+        try:
+            bad_port = 99999
+            hookenv.config()["jnlp-port"] = bad_port
+            bootstrap = self.configuration.bootstrap()
+            self.assertFalse(bootstrap)
+        finally:
+            # Reset our port
+            hookenv.config()["jnlp-port"] = orig_port
 
     def test_set_url(self):
         needs_restart = self.configuration.set_url()

--- a/unit_tests/test_credentials.py
+++ b/unit_tests/test_credentials.py
@@ -38,9 +38,13 @@ class CredentialsTest(CharmTest):
         """
         The username matches then one set in the service configuration.
         """
-        self.fakes.juju.config["username"] = "joe"
-        self.useFixture(JenkinsConfiguredAdmin(self.fakes))
-        self.assertEqual("joe", self.credentials.username())
+        orig_username = hookenv.config()["username"]
+        try:
+            hookenv.config()["username"] = "joe"
+            self.useFixture(JenkinsConfiguredAdmin(self.fakes))
+            self.assertEqual("joe", self.credentials.username())
+        finally:
+            hookenv.config()["username"] = orig_username
 
     def test_password_initial(self):
         """
@@ -54,9 +58,13 @@ class CredentialsTest(CharmTest):
         """
         If set, the password matches the one set in the service configuration.
         """
-        self.fakes.juju.config["password"] = "sekret"
-        self.useFixture(JenkinsConfiguredAdmin(self.fakes))
-        self.assertEqual("sekret", self.credentials.password())
+        orig_password = hookenv.config()["password"]
+        try:
+            hookenv.config()["password"] = "sekret"
+            self.useFixture(JenkinsConfiguredAdmin(self.fakes))
+            self.assertEqual("sekret", self.credentials.password())
+        finally:
+            hookenv.config()["password"] = orig_password
 
     def test_password_from_local_state(self):
         """

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -29,7 +29,7 @@ class PackagesTest(CharmTest):
         # Reset installs and sources after each test
         super(PackagesTest, self).tearDown()
         self.packages.installs = []
-        self.sources = []
+        self.packages.sources = []
 
     def test_install_dependencies(self):
         """
@@ -107,13 +107,17 @@ class PackagesTest(CharmTest):
         If the 'release' config is set to 'trunk', an APT source entry will be
         added, pointing to the debian Jenkins repository.
         """
-        self.fakes.juju.config["release"] = "trunk"
-        self.packages.install_jenkins()
-        source = APT_SOURCE % "debian"
-        key = os.path.join(hookenv.charm_dir(), "jenkins.io.key")
-        with open(key, "r") as k:
-            key = k.read()
-        self.assertEqual([(source, key)], self.apt.sources)
+        orig_release = hookenv.config()["release"]
+        try:
+            hookenv.config()["release"] = "trunk"
+            self.packages.install_jenkins()
+            source = APT_SOURCE % "debian"
+            key = os.path.join(hookenv.charm_dir(), "jenkins.io.key")
+            with open(key, "r") as k:
+                key = k.read()
+            self.assertEqual([(source, key)], self.apt.sources)
+        finally:
+            hookenv.config()["release"] = orig_release
 
     def test_install_jenkins_invalid_release(self):
         """

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -71,12 +71,16 @@ class PackagesTest(CharmTest):
         If the 'release' config is set to 'bundle' but no jenkins.deb file is
         present, an error is raised.
         """
-        self.fakes.juju.config["release"] = "bundle"
-        error = self.assertRaises(Exception, self.packages.install_jenkins)
-        path = os.path.join(hookenv.charm_dir(), "files", "jenkins.deb")
-        self.assertEqual(
-            "'{}' doesn't exist. No package bundled.".format(path),
-            str(error))
+        orig_release = hookenv.config()["release"]
+        try:
+            hookenv.config()["release"] = "bundle"
+            error = self.assertRaises(Exception, self.packages.install_jenkins)
+            path = os.path.join(hookenv.charm_dir(), "files", "jenkins.deb")
+            self.assertEqual(
+                "'{}' doesn't exist. No package bundled.".format(path),
+                str(error))
+        finally:
+            hookenv.config()["release"] = orig_release
 
     def test_install_jenkins_remote(self):
         """
@@ -123,7 +127,11 @@ class PackagesTest(CharmTest):
         """
         If the 'release' config is invalid, an error is raised.
         """
-        self.fakes.juju.config["release"] = "foo"
-        error = self.assertRaises(Exception, self.packages.install_jenkins)
-        self.assertEqual(
-            "Release 'foo' configuration not recognised", str(error))
+        orig_release = hookenv.config()["release"]
+        try:
+            hookenv.config()["release"] = "foo"
+            error = self.assertRaises(Exception, self.packages.install_jenkins)
+            self.assertEqual(
+                "Release 'foo' configuration not recognised", str(error))
+        finally:
+            hookenv.config()["release"] = orig_release

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -25,6 +25,12 @@ class PackagesTest(CharmTest):
         os.symlink(os.path.join(os.getcwd(), keyfile),
                    os.path.join(hookenv.charm_dir(), keyfile))
 
+    def tearDown(self):
+        # Reset installs and sources after each test
+        super(PackagesTest, self).tearDown()
+        self.packages.installs = []
+        self.sources = []
+
     def test_install_dependencies(self):
         """
         The Jenkins dependencies get installed by the install_dependencies
@@ -37,9 +43,13 @@ class PackagesTest(CharmTest):
         """
         The requested tools get installed by the install_tools method.
         """
-        self.fakes.juju.config["tools"] = "git gcc"
-        self.packages.install_tools()
-        self.assertEqual(["git", "gcc"], self.apt.installs)
+        orig_tools = hookenv.config()["tools"]
+        try:
+            hookenv.config()["tools"] = "git gcc"
+            self.packages.install_tools()
+            self.assertEqual(["git", "gcc"], self.apt.installs)
+        finally:
+            hookenv.config()["tools"] = orig_tools
 
     def test_install_jenkins_bundle(self):
         """

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -56,15 +56,19 @@ class PackagesTest(CharmTest):
         If the 'release' config is set to 'bundle', then Jenkins will be
         installed from a local jenkins.deb file.
         """
-        self.fakes.juju.config["release"] = "bundle"
-        files = os.path.join(hookenv.charm_dir(), "files")
-        os.mkdir(files)
-        bundle_path = os.path.join(files, "jenkins.deb")
-        with open(bundle_path, "w") as fd:
-            fd.write("")
-        self.packages.install_jenkins()
-        self.assertEqual(
-            ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+        orig_release = hookenv.config()["release"]
+        try:
+            hookenv.config()["release"] = "bundle"
+            files = os.path.join(hookenv.charm_dir(), "files")
+            os.mkdir(files)
+            bundle_path = os.path.join(files, "jenkins.deb")
+            with open(bundle_path, "w") as fd:
+                fd.write("")
+            self.packages.install_jenkins()
+            self.assertEqual(
+                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+        finally:
+            hookenv.config()["release"] = orig_release
 
     def test_install_jenkins_bundle_no_file(self):
         """
@@ -89,10 +93,14 @@ class PackagesTest(CharmTest):
         """
         self.fakes.processes.wget.locations[
             "http://jenkins-1.2.3.deb"] = b"data"
-        self.fakes.juju.config["release"] = "http://jenkins-1.2.3.deb"
-        self.packages.install_jenkins()
-        self.assertEqual(
-            ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+        orig_release = hookenv.config()["release"]
+        try:
+            hookenv.config()["release"] = "http://jenkins-1.2.3.deb"
+            self.packages.install_jenkins()
+            self.assertEqual(
+                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+        finally:
+            hookenv.config()["release"] = orig_release
 
     def test_install_jenkins_lts_release(self):
         """

--- a/unit_tests/test_users.py
+++ b/unit_tests/test_users.py
@@ -33,19 +33,23 @@ class UsersTest(JenkinsTest):
         If a password is provided, it's used to configure the admin user.
         """
         config = hookenv.config()
-        config["password"] = "x"
+        orig_password = config["password"]
+        try:
+            config["password"] = "x"
 
-        script = UPDATE_PASSWORD_SCRIPT.format(username="admin", password="x")
-        self.fakes.jenkins.scripts[script] = ""
+            script = UPDATE_PASSWORD_SCRIPT.format(username="admin", password="x")
+            self.fakes.jenkins.scripts[script] = ""
 
-        self.users.configure_admin()
+            self.users.configure_admin()
 
-        self.assertThat(paths.ADMIN_PASSWORD, FileContains("x"))
-        self.assertThat(paths.ADMIN_PASSWORD, HasOwnership(0, 0))
-        self.assertThat(paths.ADMIN_PASSWORD, HasPermissions("0600"))
+            self.assertThat(paths.ADMIN_PASSWORD, FileContains("x"))
+            self.assertThat(paths.ADMIN_PASSWORD, HasOwnership(0, 0))
+            self.assertThat(paths.ADMIN_PASSWORD, HasPermissions("0600"))
 
-        self.assertThat(paths.LAST_EXEC, FileContains("2.0.0\n"))
-        self.assertThat(paths.LAST_EXEC, HasOwnership(123, 456))
+            self.assertThat(paths.LAST_EXEC, FileContains("2.0.0\n"))
+            self.assertThat(paths.LAST_EXEC, HasOwnership(123, 456))
+        finally:
+            config["password"] = orig_password
 
     def test_configure_admin_random_password(self):
         """


### PR DESCRIPTION
Charm test seems to no longer reset test data between tests, so update all tests to do this where appropriate.

Also added lxc-test which allows for easier running of tests locally and allows us to specify which version of Ubuntu tests should be run on.