### PR TITLE
convert our Jenkins API code to work properly with requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 .tox
 .cache
 .coverage

--- a/unit_tests/fakes.py
+++ b/unit_tests/fakes.py
@@ -47,7 +47,7 @@ class FakeJenkins(Fixture):
         return self.scripts[script]
 
     def jenkins_open(self, request):
-        response = self.responses[request.full_url]
+        response = self.responses[request.url]
         if isinstance(response, Exception):
             raise response
         return response

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,2 @@
-# The 0.4.11 version currently in Ubuntu/Debian is buggy, see LP #1500898
-python-jenkins>=0.4.13
+# We require a version of python-jenkins that uses requests.
+python-jenkins>=0.4.16


### PR DESCRIPTION
python-jenkins uses requests as of version 0.4.16.  The previous build of the charm shipped 0.4.15, and fresh builds are shipping 1.4.0.

This branch updates the charm's Jenkins API code to use the correct type of Request object and to retry correctly during Jenkins startup by catching the requests-flavoured exceptions.