### PR TITLE
Try JUJU_CHARM_*_PROXY settings when fetching jenkins deb

### DIFF
--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -102,6 +102,18 @@ class PackagesTest(CharmTest):
         finally:
             hookenv.config()["release"] = orig_release
 
+    def test_install_jenkins_remote_with_proxy(self):
+        """
+        If the 'release' config is set to a remote URL, then Jenkins will be
+        installed from the deb files pointed by that url.
+        """
+        env_backup = os.environ.copy()
+        try:
+            os.environ['JUJU_CHARM_HTTP_PROXY'] = "http://pr.oxy:1234"
+            self.test_install_jenkins_remote()
+        finally:
+            os.environ = env_backup
+
     def test_install_jenkins_lts_release(self):
         """
         If the 'release' config is set to 'lts', an APT source entry will be


### PR DESCRIPTION
If our model has juju proxy settings and we've been told to
fetch a specific deb, set the corresponding *_proxy variables
when doing so. If the user has set JUJU HTTP(S)/FTP proxies,
but has pointed us to an internally hosted deb, hopefully
they've also set JUJU_CHARM_NO_PROXY appropriately. But,
just in case, leave the fallback of fetching w an unmodified
environment.