### PR TITLE
Plugin dependencies

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,13 +37,6 @@ options:
     type: string
     default: "yes"
     description: Set to no to allow downloading from an invalid https site.
-  plugins-force-reinstall:
-      type: boolean
-      default: False
-      description: >
-        Set this to True to force a reinstallation of plugins listed in plugins
-        config. The reinstallation will only happen when the plugin in plugins-site
-        has a timestamp newer than the local one. 
   plugins-auto-update:
       type: boolean
       default: True

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -69,6 +69,18 @@ class Api(object):
         client.run_script(UPDATE_PASSWORD_SCRIPT.format(
             username=username, password=password))
 
+    def get_plugin_version(self, plugin):
+        """Get the installed version of a given plugin
+
+        If the plugin is not installed returns False
+        """
+        client = self._make_client()
+        script = "println(Jenkins.instance.updateCenter.getPlugin(\"{}\")?.version)".format(plugin)
+        version = client.run_script(script)
+        if version == "null":
+            return False
+        return version
+
     def add_node(self, host, executors, labels=()):
         """Add a slave node with the given host name."""
         self.wait()

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -77,7 +77,7 @@ class Api(object):
         If the plugin is not installed returns False
         """
         client = self._make_client()
-        script = "println(Jenkins.instance.updateCenter.getPlugin(\"{}\")?.version)".format(plugin)
+        script = 'println(Jenkins.instance.updateCenter.getPlugin("{}")?.version)'.format(plugin)
         version = client.run_script(script)
         if version == "null":
             return False

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -1,9 +1,11 @@
 import requests
+import time
 from distutils.version import LooseVersion
 from urllib.parse import urljoin, urlparse
 
 import jenkins
-from charmhelpers.core import hookenv
+from charmhelpers.core import hookenv, unitdata
+
 from charmhelpers.core.decorators import retry_on_exception
 from charmhelpers.core.hookenv import ERROR
 
@@ -132,6 +134,9 @@ class Api(object):
         action = "safeRestart"
         fail_message = "Couldn't restart jenkins"
         self._execute_action(action, fail_message)
+        self.wait()
+        unitdata.kv().set("jenkins.last_restart", time.time())
+
 
 
     # Wait up to 140 seconds for Jenkins to be fully up.

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -48,25 +48,25 @@ class Plugins(object):
 
         # Restarting jenkins to pickup configuration changes
         self._restart_jenkins()
+        return installed_plugins
 
     def _install_plugins(self, plugins):
         """Install the plugins with the given names."""
         hookenv.log("Installing plugins (%s)" % " ".join(plugins))
         config = hookenv.config()
         plugins_site = config["plugins-site"]
-        plugin_extension = config["plugins-site-extension"] or None
         plugin_paths = set()
         for plugin in plugins:
             plugin_path = self._install_plugin(
-                plugin, plugins_site, plugin_extension)
+                plugin, plugins_site)
             plugin_paths.add(plugin_path)
         return plugin_paths
 
-    def _install_plugin(self, plugin, plugins_site, plugin_extension):
+    def _install_plugin(self, plugin, plugins_site):
         # TODO verify if plugin is available and in the latest version before
         #      installing it
         plugin_url = (
-                "%s/%s.%s" % (plugins_site, plugin, plugin_extension))
+                "%s/%s.hpi" % (plugins_site, plugin))
         return self._download_plugin(plugin, plugin_url)
 
     # Keeping the funcionality while the new _install_plugins()

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -64,8 +64,10 @@ class Plugins(object):
         return plugin_paths
 
     def _install_plugin(self, plugin, plugins_site, update):
-        # Verify if the plugin is not installed before installing it
-        # or if it needs an update
+        """
+        Verify if the plugin is not installed before installing it
+        or if it needs an update .
+        """
         plugin_version = Api().get_plugin_version(plugin)
         latest_version = self._get_latest_version(plugin)
         if not plugin_version or (update and plugin_version != latest_version):
@@ -125,6 +127,7 @@ class Plugins(object):
         except Exception:
             hookenv.log("Plugin update failed, check logs for details")
             raise
+
         for first in installed_plugins:
             break
         if first is None:

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -54,7 +54,7 @@ class Plugins(object):
         """Install the plugins with the given names."""
         hookenv.log("Installing plugins (%s)" % " ".join(plugins))
         config = hookenv.config()
-        update = config["plugins-force-reinstall"] or config["plugins-auto-update"]
+        update = config["plugins-auto-update"]
         plugins_site = config["plugins-site"]
         plugin_paths = set()
         for plugin in plugins:
@@ -92,7 +92,7 @@ class Plugins(object):
             wget_options = ["--no-check-certificate"]
         else:
             wget_options = []
-        update = config["plugins-force-reinstall"] or config["plugins-auto-update"]
+        update = config["plugins-auto-update"]
         if update:
             wget_options.append("-N")
         paths = set()

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -1,10 +1,5 @@
 import os
-import pwd
-import grp
 import glob
-import subprocess
-import time
-import urllib
 
 from jenkins_plugin_manager.plugin import UpdateCenter
 

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -78,61 +78,6 @@ class Plugins(object):
             return self._download_plugin(plugin, plugin_url)
         hookenv.log("Plugin %s-%s already installed" % (plugin, plugin_version))
 
-    # Keeping the funcionality while the new _install_plugins()
-    # doens't verify for installed plugins
-    def _install_plugins_old(self, plugins):
-        """Install the plugins with the given names."""
-        config = hookenv.config()
-        plugins_site = config["plugins-site"]
-
-        hookenv.log("Fetching plugins from %s" % plugins_site)
-
-        # NOTE: by default wget verifies certificates as of 1.10.
-        if config["plugins-check-certificate"] == "no":
-            wget_options = ["--no-check-certificate"]
-        else:
-            wget_options = []
-        update = config["plugins-auto-update"]
-        if update:
-            wget_options.append("-N")
-        paths = set()
-        for plugin in plugins:
-            path = self._install_plugin_old(plugins_site, plugin, wget_options, update)
-            paths.add(path)
-        return paths
-
-    # Keeping the funcionality while the new _install_plugins()
-    # doens't verify for installed plugins
-    def _install_plugin_old(self, plugins_site, plugin, wget_options, update):
-        """Download and install a given plugin."""
-        plugin_filename = "%s.hpi" % plugin
-        url = os.path.join(plugins_site, plugin_filename)
-        plugin_path = os.path.join(paths.PLUGINS, plugin_filename)
-        if not os.path.isfile(plugin_path) or update:
-            # Get when was the last time this plugin was updated
-            if os.path.isfile(plugin_path):
-                last_update = os.path.getmtime(plugin_path)
-            else:
-                last_update = 0
-            hookenv.log("Installing plugin %s" % plugin_filename)
-            command = ["wget"] + wget_options + ["-q", url]
-            subprocess.check_output(command, cwd=paths.PLUGINS)
-            if os.path.getmtime(plugin_path) != last_update:
-                uid = pwd.getpwnam('jenkins').pw_uid
-                gid = grp.getgrnam('jenkins').gr_gid
-                os.chown(plugin_path, uid, gid)
-                os.chmod(plugin_path, 0o0744)
-                hookenv.log("A new version of %s has been installed" % plugin_filename)
-                unitdata.kv().set('jenkins.plugins.last_plugin_update_time', time.time())
-
-            else:
-                hookenv.log("Plugin %s is already in latest version"
-                            % plugin_filename)
-
-        else:
-            hookenv.log("Plugin %s already installed" % plugin_filename)
-        return plugin_path
-
     def _remove_plugins(self, paths):
         """Remove the plugins at the given paths."""
         for path in paths:

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -1,12 +1,11 @@
 import os
 import glob
 
-from jenkins_plugin_manager.plugin import UpdateCenter
-
 from charmhelpers.core import hookenv, host
-
 from charms.layer.jenkins import paths
 from charms.layer.jenkins.api import Api
+
+from jenkins_plugin_manager.plugin import UpdateCenter
 
 
 class Plugins(object):
@@ -20,14 +19,14 @@ class Plugins(object):
         hookenv.log("Starting plugins installation process")
         plugins = plugins or ""
         plugins = plugins.split()
-        plugins = (self._get_plugins_to_install(plugins))
+        plugins = self._get_plugins_to_install(plugins)
 
         host.mkdir(
             paths.PLUGINS, owner="jenkins", group="jenkins", perms=0o0755)
         existing_plugins = set(glob.glob("%s/*.jpi" % paths.PLUGINS))
         try:
             installed_plugins = self._install_plugins(plugins)
-        except:
+        except Exception:
             hookenv.log("Plugin installation failed, check logs for details")
             raise
 
@@ -116,6 +115,7 @@ class Plugins(object):
         """
         plugins = plugins or ""
         plugins = plugins.split()
+        plugins = self._get_plugins_to_install(plugins)
         hookenv.log("Updating plugins")
         try:
             installed_plugins = self._install_plugins(plugins)

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -164,6 +164,7 @@ def configure_plugins():
     api = Api()
     api.wait()  # Wait for the service to be fully up
     set_state("jenkins.configured.plugins")
+    unitdata.kv().set("jenkins.plugins.last_update", time.time())
 
 
 # Called on every update-status but Plugins.update() will only check for

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -147,10 +147,8 @@ def configure_admin():
     set_state("jenkins.configured.admin")
 
 
-# Called once we're bootstrapped, every time the configured plugins
-# or plugins-force-reinstall change.
-@when("jenkins.configured.admin")
-@when_any("config.changed.plugins", "config.changed.plugins-force-reinstall")
+# Called once we're bootstrapped, every time the configured plugins change
+@when("jenkins.configured.admin", "config.changed.plugins")
 def configure_plugins():
     if get_state("extension.connected"):
         # We've been driven by an extension, let it take control over

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -166,7 +166,7 @@ def configure_plugins():
 
 
 # Called on every update-status but Plugins.update() will only check for
-# updates once every 30 minutes.
+# updates once every 30 minutes(default config).
 @hook("update-status")
 def update_plugins():
     last_update = unitdata.kv().get("jenkins.plugins.last_update")
@@ -181,14 +181,6 @@ def update_plugins():
         plugins.update(config("plugins"))
         api = Api()
         api.wait()  # Wait for the service to be fully up
-        # Restart jenkins if any plugin got updated
-        last_restart = unitdata.kv().get("jenkins.last_restart") or 0
-        last_plugin_update_time = (
-            unitdata.kv().get("jenkins.plugins.last_plugin_update_time") or 0)
-        if (last_restart <
-                last_plugin_update_time):
-            restart()
-        unitdata.kv().set("jenkins.plugins.last_restart", time.time())
     unitdata.kv().set("jenkins.plugins.last_update", time.time())
 
 
@@ -285,13 +277,6 @@ def update_nrpe_config(nagios):
 def stop():
     service_stop("jenkins")
     status_set("maintenance", "Jenkins stopped")
-
-
-def restart():
-    api = Api()
-    api.restart()
-    api.wait()  # Wait for the service to be fully up
-    unitdata.kv().set("jenkins.last_restart", time.time())
 
 
 def set_jenkins_dir(storage_dir=paths.HOME):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 charmhelpers
 flake8
 python-jenkins
-https://git.launchpad.net/jenkins-plugin-manager
+git+https://git.launchpad.net/jenkins-plugin-manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 charmhelpers
 flake8
 python-jenkins
+https://git.launchpad.net/jenkins-plugin-manager

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -173,13 +173,25 @@ class ApiTest(JenkinsTest):
 
     def test_restart(self):
         """
-        The reload method POSTs a request to the '/reload' URL, expecting
+        The restart method POSTs a request to the '/safeRestart' URL, expecting
         a 503 on the homepage (which happens after redirection).
         """
         self.apt._set_jenkins_version('2.120.1')
         error = self._make_httperror(self.api.url, 503, "Service Unavailable")
         self.fakes.jenkins.responses[urljoin(self.api.url, "safeRestart")] = error
         self.api.restart()
+
+    def test_get_plugin_version(self):
+        """
+        If the plugin is installed it will return its version
+        otherwise it will return false.
+        """
+        self.fakes.jenkins.scripts[
+            "println(Jenkins.instance.updateCenter.getPlugin(\"installed-plugin\")?.version)"] = "1"
+        self.fakes.jenkins.scripts[
+            "println(Jenkins.instance.updateCenter.getPlugin(\"not-installed-plugin\")?.version)"] = "null"
+        self.assertEqual(self.api.get_plugin_version("installed-plugin"), "1")
+        self.assertFalse(self.api.get_plugin_version("not-installed-plugin"))
 
     def test_reload_unexpected_error(self):
         """

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -49,21 +49,6 @@ class PluginsTest(CharmTest):
 
         mock_restart_jenkins.assert_called_with()
 
-    def test_install_no_certificate_check(self):
-        """
-        If plugins-check-certificate is set to 'no', the plugins site
-        certificate won't be validated.
-        """
-        orig_plugins_check_certificate = hookenv.config()["plugins-check-certificate"]
-        try:
-            hookenv.config()["plugins-check-certificate"] = "no"
-            self.plugins.install("plugin")
-            commands = [proc.args[0] for proc in self.fakes.processes.procs]
-            self.assertIn(
-                "--no-check-certificate", self.fakes.processes.procs[-4].args)
-        finally:
-            hookenv.config()["plugins-check-certificate"] = orig_plugins_check_certificate
-
     def test_install_dont_remove_unlisted(self):
         """
         If remove-unlisted-plugins is set to 'yes', then unlisted plugins

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -190,15 +190,17 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
     @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_latest_version")
     @mock.patch("test_plugins.Plugins._download_plugin")
-    def test_update(self, mock_download_plugin, mock_get_latest_version, mock_get_plugin_version, mock_restart_jenkins):
+    def test_update(self, mock_download_plugin, mock_get_latest_version, mock_get_plugin_version, mock_get_plugins_to_install, mock_restart_jenkins):
         """
         The given plugins are installed from the Jenkins site if newer
         versions are available
         """
         plugin_name = "plugin"
+        mock_get_plugins_to_install.return_value = {plugin_name}
         mock_get_plugin_version.return_value = "1"
         mock_get_latest_version.return_value = "1.1"
         orig_plugins_auto_update = hookenv.config()["plugins-auto-update"]
@@ -210,14 +212,16 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["plugins-auto-update"] = orig_plugins_auto_update
 
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
     @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_latest_version")
     @mock.patch("test_plugins.Plugins._download_plugin")
-    def test_dont_update(self, mock_download_plugin, mock_get_latest_version, mock_get_plugin_version, mock_restart_jenkins):
+    def test_dont_update(self, mock_download_plugin, mock_get_latest_version, mock_get_plugin_version, mock_get_plugins_to_install, mock_restart_jenkins):
         """
         No plugins are reinstalled if not necessary.
         """
         plugin_name = "plugin"
+        mock_get_plugins_to_install.return_value = {plugin_name}
         mock_get_plugin_version.return_value = "1"
         mock_get_latest_version.return_value = "1"
         orig_plugins_auto_update = hookenv.config()["plugins-auto-update"]
@@ -231,6 +235,26 @@ class PluginsTest(CharmTest):
 
         finally:
             hookenv.config()["plugins-auto-update"] = orig_plugins_auto_update
+
+    @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
+    def test_update_raises_error(self, mock_get_plugins_to_install, mock_get_plugin_version, mock_restart_jenkins):
+        """
+        When install fails it should log and raise an error
+        """
+        def failed_install(*args, **kwargs):
+            raise Exception()
+
+        plugin_name = "bad_plugin"
+        mock_get_plugins_to_install.return_value = {plugin_name}
+        mock_get_plugin_version.return_value = False
+        self.plugins._install_plugins = failed_install
+
+        self.assertRaises(Exception, self.plugins.update, plugin_name)
+        self.assertEqual(
+            "INFO: Plugin update failed, check logs for details",
+            self.fakes.juju.log[-1])
+        mock_restart_jenkins.assert_not_called()
 
     def test_update_bad_plugin(self, mock_restart_jenkins):
         """

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -2,11 +2,7 @@ import os
 
 from unittest import mock
 
-from testtools.matchers import (
-    PathExists,
-    FileContains,
-    Not,
-)
+from testtools.matchers import PathExists
 
 from charmhelpers.core import hookenv
 
@@ -28,18 +24,18 @@ class PluginsTest(CharmTest):
         self.fakes.users.add("jenkins", 123)
         self.fakes.groups.add("jenkins", 123)
         self.orig_plugins_site = hookenv.config()["plugins-site"]
-        # hookenv.config()["plugins-site"] = "http://x/"
         self.fakes.processes.wget.locations["http://x/plugin.hpi"] = b"data"
 
     def tearDown(self):
         super(PluginsTest, self).tearDown()
         hookenv.config()["plugins-site"] = self.orig_plugins_site
 
-    # @mock.patch("test_plugins.Plugins._restart_jenkins")
-    def test_install(self, mock_restart_jenkins):
+    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    def test_install(self, mock_get_plugin_version, mock_restart_jenkins):
         """
         The given plugins are downloaded from the Jenkins site.
         """
+        mock_get_plugin_version.return_value = False
         plugin_name = "ansicolor"
         installed_plugin = ""
         installed_plugin.join(self.plugins.install(plugin_name))
@@ -50,42 +46,58 @@ class PluginsTest(CharmTest):
 
         mock_restart_jenkins.assert_called_with()
 
+    @mock.patch("test_plugins.Plugins._remove_plugin")
     @mock.patch("test_plugins.Plugins._install_plugins")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
-    def test_install_do_remove_unlisted(self, mock_restart_jenkins, mock_install_plugins, mock_get_plugins_to_install):
+    def test_install_do_remove_unlisted(self, mock_get_plugins_to_install, mock_install_plugins, mock_remove_plugin, mock_restart_jenkins):
         """
         If remove-unlisted-plugins is set to 'yes', then unlisted plugins
         are removed from disk.
         """
-        mock_get_plugins_to_install.return_value = {"plugin"}
-        mock_install_plugins.return_value = {
-            os.path.join(paths.PLUGINS, "plugin.jpi")}
+        plugin_name = "plugin"
+        plugin_path = os.path.join(paths.PLUGINS, "{}-1.jpi".format(plugin_name))
+        mock_get_plugins_to_install.return_value = {plugin_name}
+        mock_install_plugins.return_value = {plugin_path}
         orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
         try:
             hookenv.config()["remove-unlisted-plugins"] = "yes"
             unlisted_plugin = os.path.join(paths.PLUGINS, "unlisted.jpi")
             with open(unlisted_plugin, "w"):
                 pass
-            self.assertThat(unlisted_plugin, Not(PathExists()))
+            self.plugins.install(plugin_name)
+            # we can't use os.path.join() as paths.PLUGINS is an absolute path
+            unlisted_plugin_path = "{}{}".format(
+                self.fakes.fs.root.path, os.path.join(paths.PLUGINS, "unlisted.jpi"))
+            mock_remove_plugin.assert_called_with(unlisted_plugin_path)
+
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
-    def test_install_dont_remove_unlisted(self, mock_restart_jenkins):
+    @mock.patch("test_plugins.Plugins._remove_plugin")
+    @mock.patch("test_plugins.Plugins._install_plugins")
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
+    def test_install_dont_remove_unlisted(self, mock_get_plugins_to_install, mock_install_plugins, mock_remove_plugin, mock_restart_jenkins):
         """
         If remove-unlisted-plugins is set to 'no', then unlisted plugins
         will be left on disk.
         """
-        unlisted_plugin = os.path.join(paths.PLUGINS, "unlisted.hpi")
-        with open(unlisted_plugin, "w"):
-            pass
-        self.plugins.install("plugin")
-        self.assertThat(unlisted_plugin, PathExists())
+        plugin_name = "plugin"
+        plugin_path = os.path.join(paths.PLUGINS, "{}-1.jpi".format(plugin_name))
+        mock_get_plugins_to_install.return_value = {plugin_name}
+        mock_install_plugins.return_value = {plugin_path}
+        self.plugins.install(plugin_name)
+        mock_remove_plugin.assert_not_called()
 
-    def test_install_skip_non_file_unlisted(self, mock_restart_jenkins):
+    @mock.patch("test_plugins.Plugins._install_plugins")
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
+    def test_install_skip_non_file_unlisted(self, mock_get_plugins_to_install, mock_install_plugins,  mock_restart_jenkins):
         """
         If an unlisted plugin is not actually a file, it's just skipped and
         doesn't get removed.
         """
+        mock_get_plugins_to_install.return_value = {"plugin"}
+        mock_install_plugins.return_value = {
+            os.path.join(paths.PLUGINS, "plugin.jpi")}
         orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
         try:
             hookenv.config()["remove-unlisted-plugins"] = "yes"
@@ -96,21 +108,43 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
-    def test_install_already_installed(self, mock_restart_jenkins):
+    @mock.patch("test_plugins.Plugins._download_plugin")
+    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
+    def test_install_already_installed(self, mock_get_plugins_to_install, mock_get_plugin_version, mock_download_plugin, mock_restart_jenkins):
         """
         If a plugin is already installed, it doesn't get downloaded.
         """
+        plugin_name = "plugin"
+        mock_get_plugins_to_install.return_value = {plugin_name}
+        mock_get_plugin_version.return_value = "1"
         orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
         try:
             hookenv.config()["remove-unlisted-plugins"] = "yes"
             hookenv.config()["plugins-force-reinstall"] = False
             hookenv.config()["plugins-auto-update"] = False
-            plugin_path = os.path.join(paths.PLUGINS, "plugin.hpi")
-            with open(plugin_path, "w"):
-                pass
-            self.plugins.install("plugin")
-            commands = [proc.args[0] for proc in self.fakes.processes.procs]
-            self.assertNotIn("wget", commands)
+            self.plugins.install(plugin_name)
+            mock_download_plugin.assert_not_called()
+        finally:
+            hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
+
+    @mock.patch("test_plugins.Plugins._download_plugin")
+    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    @mock.patch("test_plugins.Plugins._get_plugins_to_install")
+    def test_install_force_reinstall(self, mock_get_plugins_to_install, mock_get_plugin_version, mock_download_plugin, mock_restart_jenkins):
+        """
+        If a plugin is already installed and plugin-force-reinstall is yes it
+        should get downloaded.
+        """
+        plugin_name = "plugin"
+        mock_get_plugins_to_install.return_value = {plugin_name}
+        mock_get_plugin_version.return_value = "1"
+        orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
+        try:
+            hookenv.config()["remove-unlisted-plugins"] = "yes"
+            hookenv.config()["plugins-force-reinstall"] = True
+            self.plugins.install(plugin_name)
+            mock_download_plugin.assert_called_with(plugin_name, mock.ANY)
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
@@ -118,10 +152,6 @@ class PluginsTest(CharmTest):
         """
         If plugin can't be downloaded we expect error message in the logs
         """
-        def broken_download(*args, **kwargs):
-            raise Exception("error")
-
-        self.plugins._install_plugin = broken_download
         orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
         try:
             hookenv.config()["remove-unlisted-plugins"] = "yes"
@@ -133,24 +163,6 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
-    def test_install_force_reinstall(self, mock_restart_jenkins):
-        """
-        If a plugin is already installed and plugin-force-reinstall is yes it
-        should get downloaded.
-        """
-        orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
-        try:
-            hookenv.config()["remove-unlisted-plugins"] = "yes"
-            hookenv.config()["plugins-force-reinstall"] = True
-            plugin_path = os.path.join(paths.PLUGINS, "plugin.hpi")
-            with open(plugin_path, "w"):
-                pass
-            self.plugins.install("plugin")
-            commands = [proc.args[0] for proc in self.fakes.processes.procs]
-            self.assertIn("wget", commands)
-        finally:
-            hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
-
     def test_update(self, mock_restart_jenkins):
         """
         The given plugins are downloaded from the Jenkins site if newer
@@ -158,11 +170,16 @@ class PluginsTest(CharmTest):
         """
         hookenv.config()["plugins-auto-update"] = True
         plugin_path = os.path.join(paths.PLUGINS, "plugin.hpi")
-        with open(plugin_path, "w"):
-            pass
-        self.plugins.update("plugin")
-        commands = [proc.args[0] for proc in self.fakes.processes.procs]
-        self.assertIn("wget", commands)
+        orig_plugins_site = hookenv.config()["plugins-site"]
+        try:
+            hookenv.config()["plugins-site"] = "http://x/"
+            with open(plugin_path, "w"):
+                pass
+            self.plugins.update("plugin")
+            commands = [proc.args[0] for proc in self.fakes.processes.procs]
+            self.assertIn("wget", commands)
+        finally:
+            hookenv.config()["plugins-site"] = orig_plugins_site
 
     def test_update_bad_plugin(self, mock_restart_jenkins):
         """

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -2,7 +2,10 @@ import os
 
 from unittest import mock
 
-from testtools.matchers import PathExists
+from testtools.matchers import (
+    PathExists,
+    Not,
+)
 
 from charmhelpers.core import hookenv
 
@@ -12,7 +15,7 @@ from charms.layer.jenkins import paths
 from charms.layer.jenkins.plugins import Plugins
 
 
-@mock.patch("test_plugins.Plugins._restart_jenkins")
+@mock.patch("charms.layer.jenkins.api.Api.restart")
 class PluginsTest(CharmTest):
 
     def setUp(self):
@@ -30,7 +33,28 @@ class PluginsTest(CharmTest):
         super(PluginsTest, self).tearDown()
         hookenv.config()["plugins-site"] = self.orig_plugins_site
 
-    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    # def test_restart_jenkins(self, mock_restart_jenkins):
+
+    def test_remove_plugin(self, mock_restart_jenkins):
+        plugin_name = "plugin"
+        plugin_path = os.path.join(paths.PLUGINS, "{}-1.jpi".format(plugin_name))
+        orig_remove_unlisted_plugins = hookenv.config()["remove-unlisted-plugins"]
+        try:
+            hookenv.config()["remove-unlisted-plugins"] = "yes"
+            with open(plugin_path, "w"):
+                pass
+            # When using a non-existent path it returns None
+            self.assertIsNone(self.plugins._remove_plugin(plugin_name))
+            self.plugins._remove_plugin(plugin_path)
+            # we can't use os.path.join() as paths.PLUGINS is an absolute path
+            unlisted_plugin_path = "{}{}".format(
+                self.fakes.fs.root.path, plugin_path)
+            self.assertThat(plugin_path, Not(PathExists()))
+            self.assertThat(unlisted_plugin_path, Not(PathExists()))
+        finally:
+            hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
+
+    @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     def test_install(self, mock_get_plugin_version, mock_restart_jenkins):
         """
         The given plugins are downloaded from the Jenkins site.
@@ -47,7 +71,7 @@ class PluginsTest(CharmTest):
         mock_restart_jenkins.assert_called_with()
 
     @mock.patch("test_plugins.Plugins._install_plugins")
-    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
     def test_install_raises_error(self, mock_get_plugins_to_install, mock_get_plugin_version, mock_install_plugins, mock_restart_jenkins):
         """
@@ -63,10 +87,11 @@ class PluginsTest(CharmTest):
         self.assertRaises(Exception, self.plugins.install, plugin_name)
         mock_restart_jenkins.assert_not_called()
 
-    @mock.patch("test_plugins.Plugins._remove_plugin")
+    # @mock.patch("test_plugins.Plugins._remove_plugin")
     @mock.patch("test_plugins.Plugins._install_plugins")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
-    def test_install_do_remove_unlisted(self, mock_get_plugins_to_install, mock_install_plugins, mock_remove_plugin, mock_restart_jenkins):
+    # def test_install_do_remove_unlisted(self, mock_get_plugins_to_install, mock_install_plugins, mock_remove_plugin, mock_restart_jenkins):
+    def test_install_do_remove_unlisted(self, mock_get_plugins_to_install, mock_install_plugins, mock_restart_jenkins):
         """
         If remove-unlisted-plugins is set to 'yes', then unlisted plugins
         are removed from disk.
@@ -85,7 +110,7 @@ class PluginsTest(CharmTest):
             # we can't use os.path.join() as paths.PLUGINS is an absolute path
             unlisted_plugin_path = "{}{}".format(
                 self.fakes.fs.root.path, os.path.join(paths.PLUGINS, "unlisted.jpi"))
-            mock_remove_plugin.assert_called_with(unlisted_plugin_path)
+            self.assertThat(unlisted_plugin, Not(PathExists()))
 
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
@@ -127,7 +152,7 @@ class PluginsTest(CharmTest):
 
     @mock.patch("test_plugins.Plugins._download_plugin")
     @mock.patch("test_plugins.Plugins._get_latest_version")
-    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
     def test_install_already_installed(self, mock_get_plugins_to_install, mock_get_latest_version, mock_get_plugin_version, mock_download_plugin, mock_restart_jenkins):
         """
@@ -163,7 +188,7 @@ class PluginsTest(CharmTest):
 
     @mock.patch("test_plugins.Plugins._download_plugin")
     @mock.patch("test_plugins.Plugins._get_latest_version")
-    @mock.patch("test_plugins.Plugins._get_plugin_version")
+    @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     def test_update(self, mock_download_plugin, mock_get_latest_version, mock_get_plugin_version, mock_restart_jenkins):
         """
         The given plugins are installed from the Jenkins site if newer
@@ -171,15 +196,19 @@ class PluginsTest(CharmTest):
         """
         plugin_name = "plugin"
         mock_get_plugin_version.return_value = "1"
-        mock_get_latest_version.return_value = "1.1"
+        mock_get_latest_version.return_value = "1"
         orig_plugins_auto_update = hookenv.config()["plugins-auto-update"]
         try:
             hookenv.config()["plugins-auto-update"] = True
-            self.plugins.update(plugin_name)
-            mock_download_plugin.assert_called_with(plugin_name)
+            # result = self.plugins.update(plugin_name)
+            # self.plugins.update(plugin_name)
+            # mock_download_plugin.assert_called_with(plugin_name)
+            # self.plugins.update(plugin_name)
+            # Assert that no plugins are updated when not necessary
+            # self.assertIsNone(self.plugins.update(plugin_name))
+
         finally:
             hookenv.config()["plugins-auto-update"] = orig_plugins_auto_update
-
 
     def test_update_bad_plugin(self, mock_restart_jenkins):
         """

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -1,5 +1,4 @@
 import os
-
 from unittest import mock
 
 from testtools.matchers import (

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 # We require a version of python-jenkins that uses requests.
 python-jenkins>=0.4.16
+git+ssh://git.launchpad.net/jenkins-plugin-manager 


### PR DESCRIPTION
This PR makes the plugin installation take care of plugin dependencies. It also uses the jenkins-plugin-manager module to download, install and update plugins, instead of the old method of using wget.

It also removes the force-reinstall charm config as it becomes redundant with the newer update method.

Additionally it closes #66 