### PR TITLE
Upgrade package from bundle-site

### DIFF
--- a/actions/upgrade
+++ b/actions/upgrade
@@ -1,0 +1,17 @@
+#!/usr/local/sbin/charm-env python3
+
+from charmhelpers.core.hookenv import (
+    action_fail,
+)
+
+import reactive.jenkins as Jenkins
+
+
+def upgrade():
+    Jenkins.upgrade_jenkins()
+
+
+try:
+    upgrade()
+except Exception as e:
+    action_fail("Failed to upgrade jenkins: {}".format(str(e)))

--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ options:
     default: ""
     description: >
       Site to download deb packages from when installing jenkins from bundle. 
-      If this configuration not set, the jenkins deb package needs to be manually 
+      If this configuration is not set, the jenkins deb package needs to be manually 
       copied over to the charm files/ dir before deployment and named jenkins.deb.
   username:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -6,15 +6,22 @@ options:
   release:
     type: string
     default: lts
-    description: |
-     Source of Jenkins, options include:
-     - lts: use the most recent Jenkins LTS release.
-     - trunk: use the most recent Jenkins release.
-     - bundle: use a bundled deb package. The jenkins deb package needs to be
-               manually copied over to the charm files/ dir before deployment
-               and named jenkins.deb. It can be downloaded from
-               http://pkg.jenkins-ci.org/debian/
-     - http(s)://...: http(s) link to a retrievable jenkins deb
+    description: >
+      Source of Jenkins, options include:
+      - lts: use the most recent Jenkins LTS release.
+      - trunk: use the most recent Jenkins release.
+      - bundle: use a bundled deb package. The bundle-site configuration should 
+      be set or the jenkins deb package needs to be manually copied over to the 
+      charm files/ dir before deployment and named jenkins.deb. It can be 
+      downloaded from http://pkg.jenkins-ci.org/debian/
+      - http(s)://...: http(s) link to a retrievable jenkins deb
+  bundle-site:
+    type: string
+    default: ""
+    description: >
+      Site to download deb packages from when installing jenkins from bundle. 
+      If this configuration not set, the jenkins deb package needs to be manually 
+      copied over to the charm files/ dir before deployment and named jenkins.deb.
   username:
     type: string
     default: admin

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -38,7 +38,6 @@ property = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword(
 user.addProperty(property)
 """
 
-
 class Api(object):
     """Encapsulate operations on the Jenkins master."""
 
@@ -77,7 +76,7 @@ class Api(object):
         If the plugin is not installed returns False
         """
         client = self._make_client()
-        script = 'println(Jenkins.instance.updateCenter.getPlugin("{}")?.version)'.format(plugin)
+        script = "println(Jenkins.instance.pluginManager.plugins.find{{it.shortName == '{}'}}?.version)".format(plugin)
         version = client.run_script(script)
         if version == "null":
             return False

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -34,7 +34,11 @@ class Packages(object):
         """
         self._apt = apt
         self._host = ch_host or host
-        self._jc = JenkinsCore()
+        core_url = hookenv.config()["bundle-site"]
+        if core_url == "":
+            self._jc = JenkinsCore()
+        else:
+            self._jc = JenkinsCore(hookenv.config()["bundle-site"])
 
     def distro_codename(self):
         """Return the distro release code name, e.g. 'precise' or 'trusty'."""
@@ -118,7 +122,14 @@ class Packages(object):
         return
 
     def jenkins_upgradable(self):
-        if (parse_version(self._jc.load_latest_core_version()) >
+        """
+            Verify if there's a new version of jenkins available.
+            Note: When bundle-site is not set the return will always
+            be True.
+        """
+        if hookenv.config()["bundle-site"] == "":
+            return True
+        if (parse_version(self._jc.core_version) >
                 parse_version(self.jenkins_version())):
             return True
         return False

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -5,8 +5,10 @@ import tempfile
 import subprocess
 
 from testtools import try_import
-
+from pkg_resources import parse_version
 from charmhelpers.core import hookenv, host
+
+from jenkins_plugin_manager.core import JenkinsCore
 
 # XXX Wrap this import with try_import since layers code won't be available
 #     when running unit tests for this layer (and in such case import errors
@@ -32,6 +34,7 @@ class Packages(object):
         """
         self._apt = apt
         self._host = ch_host or host
+        self._jc = JenkinsCore()
 
     def distro_codename(self):
         """Return the distro release code name, e.g. 'precise' or 'trusty'."""
@@ -110,3 +113,12 @@ class Packages(object):
         with open(keyfile, "r") as k:
             key = k.read()
         self._apt.add_source(source, key=key)
+
+    def _bundle_download(self):
+        return
+
+    def jenkins_upgradable(self):
+        if (parse_version(self._jc.load_latest_core_version()) >
+                parse_version(self.jenkins_version())):
+            return True
+        return False

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -81,8 +81,10 @@ class Packages(object):
                 message = "'%s' doesn't exist. No package bundled." % (bundle_path)
                 raise Exception(message)
         else:
-            bundle_path = os.path.join(hookenv.charm_dir(), "jenkins.deb")
-            self._bundle_download(bundle_path)
+            self._jc.jenkins_repo = hookenv.config()["bundle-site"]
+            download_path = os.path.join(hookenv.charm_dir(), "files")
+            self._bundle_download(download_path)
+            bundle_path = os.path.join(download_path, "jenkins_%s_all.deb" % self._jc.core_version)
         hookenv.log(
             "Installing from bundled Jenkins package: %s:" % bundle_path)
         self._install_local_deb(bundle_path)

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -86,9 +86,12 @@ def install_jenkins():
 @hook("upgrade-charm")
 def upgrade_jenkins():
     if config("release") == "bundle":
-        status_set("maintenance", "Upgrading Jenkins")
         packages = Packages()
-        packages.install_jenkins()
+        if packages.jenkins_upgradable():
+            status_set("maintenance", "Upgrading Jenkins")
+            packages.install_jenkins()
+        else:
+            log("No newer jenkins package is available")
 
 
 # Called once the jenkins package has been installed, but we didn't

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -85,9 +85,10 @@ def install_jenkins():
 # is a good hint that we should upgrade everything possible.
 @hook("upgrade-charm")
 def upgrade_jenkins():
-    status_set("maintenance", "Upgrading Jenkins")
-    packages = Packages()
-    packages.install_jenkins()
+    if config("release") == "bundle":
+        status_set("maintenance", "Upgrading Jenkins")
+        packages = Packages()
+        packages.install_jenkins()
 
 
 # Called once the jenkins package has been installed, but we didn't

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -187,9 +187,9 @@ class ApiTest(JenkinsTest):
         otherwise it will return false.
         """
         self.fakes.jenkins.scripts[
-            "println(Jenkins.instance.updateCenter.getPlugin(\"installed-plugin\")?.version)"] = "1"
+            "println(Jenkins.instance.pluginManager.plugins.find{it.shortName == 'installed-plugin'}?.version)"] = "1"
         self.fakes.jenkins.scripts[
-            "println(Jenkins.instance.updateCenter.getPlugin(\"not-installed-plugin\")?.version)"] = "null"
+            "println(Jenkins.instance.pluginManager.plugins.find{it.shortName == 'not-installed-plugin'}?.version)"] = "null"
         self.assertEqual(self.api.get_plugin_version("installed-plugin"), "1")
         self.assertFalse(self.api.get_plugin_version("not-installed-plugin"))
 

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -1,4 +1,5 @@
 import os
+import glob
 
 from unittest import mock
 
@@ -210,10 +211,10 @@ class PackagesTest(CharmTest):
         orig_bundle_site = hookenv.config()["bundle-site"]
         try:
             hookenv.config()["release"] = "bundle"
-            hookenv.config()["bundle-site"] = "http://test"
-            bundle_path = os.path.join(hookenv.charm_dir(), "jenkins.deb")
+            hookenv.config()["bundle-site"] = "https://pkg.jenkins.io"
+            bundle_path = os.path.join(hookenv.charm_dir(), "files")
             self.packages.install_jenkins()
-            self.assertThat(bundle_path, PathExists())
+            self.assertTrue(glob.glob('%s/jenkins_*.deb' % bundle_path))
             self.assertEqual(
                 ["install"], self.fakes.processes.dpkg.actions["jenkins"])
         finally:

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -1,5 +1,7 @@
 import os
 
+from unittest import mock
+
 from charmtest import CharmTest
 
 from charmhelpers.core import hookenv
@@ -159,3 +161,15 @@ class PackagesTest(CharmTest):
         # And now test older version.
         self.apt._set_jenkins_version('2.128.1')
         self.assertEqual(self.packages.jenkins_version(), '2.128.1')
+
+    @mock.patch("jenkins_plugin_manager.core.JenkinsCore.load_latest_core_version")
+    def test_jenkins_upgradable(self, mock_load_latest_core_version):
+        print(Packages.__dict__)
+        self.apt._set_jenkins_version('2.128.1')
+        mock_load_latest_core_version.return_value = '2.128.1'
+        self.assertFalse(self.packages.jenkins_upgradable())
+        mock_load_latest_core_version.return_value = '2.128.2'
+        self.assertTrue(self.packages.jenkins_upgradable())
+
+    def test_bundle_download(self):
+        self.packages._bundle_download()

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -2,6 +2,11 @@ import os
 
 from unittest import mock
 
+from testtools.matchers import (
+    PathExists,
+    Not,
+)
+
 from charmtest import CharmTest
 
 from charmhelpers.core import hookenv
@@ -90,8 +95,9 @@ class PackagesTest(CharmTest):
         orig_release = hookenv.config()["release"]
         try:
             hookenv.config()["release"] = "bundle"
-            error = self.assertRaises(Exception, self.packages.install_jenkins)
             path = os.path.join(hookenv.charm_dir(), "files", "jenkins.deb")
+            self.assertThat(path, Not(PathExists()))
+            error = self.assertRaises(Exception, self.packages._install_from_bundle)
             self.assertEqual(
                 "'{}' doesn't exist. No package bundled.".format(path),
                 str(error))
@@ -162,14 +168,54 @@ class PackagesTest(CharmTest):
         self.apt._set_jenkins_version('2.128.1')
         self.assertEqual(self.packages.jenkins_version(), '2.128.1')
 
-    @mock.patch("jenkins_plugin_manager.core.JenkinsCore.load_latest_core_version")
-    def test_jenkins_upgradable(self, mock_load_latest_core_version):
-        print(Packages.__dict__)
+    def test_jenkins_upgradable_without_bundle_site(self):
+        """
+        Jenkins should always be upgradable when bundle-site
+        isn't set.
+        """
+        self.assertTrue(self.packages.jenkins_upgradable())
         self.apt._set_jenkins_version('2.128.1')
-        mock_load_latest_core_version.return_value = '2.128.1'
-        self.assertFalse(self.packages.jenkins_upgradable())
-        mock_load_latest_core_version.return_value = '2.128.2'
+        self.packages._jc.core_version = '2.128.1'
         self.assertTrue(self.packages.jenkins_upgradable())
 
+    @mock.patch("charms.layer.jenkins.packages.JenkinsCore")
+    def test_jenkins_upgradable_with_bundle_site(self, mock_jenkins_core_version):
+        """
+        If the latest jenkins package version available in bundle-site is
+        higher than the installed one, jenkins will be upgradable.
+        """
+        orig_bundle_site = hookenv.config()["bundle-site"]
+        try:
+            hookenv.config()["bundle-site"] = "http://test"
+            self.packages = Packages(apt=self.apt, ch_host=self.ch_host)
+            self.apt._set_jenkins_version('2.128.1')
+            self.packages._jc.core_version = '2.128.2'
+            self.assertTrue(self.packages.jenkins_upgradable())
+            self.packages._jc.core_version = '2.128.1'
+            self.assertFalse(self.packages.jenkins_upgradable())
+        finally:
+            hookenv.config()["bundle-site"] = orig_bundle_site
+
     def test_bundle_download(self):
-        self.packages._bundle_download()
+        bundle_path = os.path.join(hookenv.charm_dir(), "jenkins.deb")
+        self.packages._bundle_download(bundle_path)
+        self.assertThat(bundle_path, PathExists())
+
+    def test_install_jenkins_bundle_download(self):
+        """
+        If the 'release' config is set to 'bundle' and bundle-site is set,
+        then Jenkins will be downloaded and installed from bundle-site.
+        """
+        orig_release = hookenv.config()["release"]
+        orig_bundle_site = hookenv.config()["bundle-site"]
+        try:
+            hookenv.config()["release"] = "bundle"
+            hookenv.config()["bundle-site"] = "http://test"
+            bundle_path = os.path.join(hookenv.charm_dir(), "jenkins.deb")
+            self.packages.install_jenkins()
+            self.assertThat(bundle_path, PathExists())
+            self.assertEqual(
+                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+        finally:
+            hookenv.config()["release"] = orig_release
+            hookenv.config()["bundle-site"] = orig_bundle_site


### PR DESCRIPTION
This MP adds a new way of upgrading jenkins package. It adds a new configuration `bundle-site` that sets an archive to download the package from if there's a newer version available.

There's also a new action to run the upgrade.