### PR TITLE
Add focal support

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -8,6 +8,6 @@ includes:
   - interface:nrpe-external-master
 options:
   basic:
-    packages: ['python3-testtools', 'pwgen']
+    packages: ['net-tools', 'python3-testtools', 'pwgen']
     include_system_packages: true
 repo: https://github.com/freeekanayaka/layer-jenkins.git

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -21,6 +21,7 @@ apt = try_import("charms.apt")
 APT_DEPENDENCIES = {
     "xenial": ["daemon", "default-jre-headless"],
     "bionic": ["daemon", "openjdk-8-jre-headless"],
+    "focal": ["daemon", "openjdk-8-jre-headless"],
 }
 APT_SOURCE = "deb http://pkg.jenkins-ci.org/%s binary/"
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,7 @@ subordinate: false
 series:
   - xenial
   - bionic
+  - focal
 provides:
   website:
     interface: http


### PR DESCRIPTION
This has been tested on bionic and focal with charm-helpers 0.20.10, and I've confirmed net-tools is available in xenial.