### PR TITLE
Set with_version=False for plugin download.

### DIFF
--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -102,7 +102,8 @@ class Plugins(object):
         """Get dependencies of the given plugin(s)"""
         uc = UpdateCenter()
         return uc.download_plugin(
-                plugin, paths.PLUGINS, plugin_url=plugin_site)
+                plugin, paths.PLUGINS, plugin_url=plugin_site,
+                with_version=False)
 
     def _get_plugin_info(self, plugin):
         """Get info of the given plugin from the UpdateCenter"""


### PR DESCRIPTION
By default, UpdateCenter will download plugins to a file like
./foo-x.y.jpi, which jenkins will unpack to a directory called ./foo-x.y.
For some versions of jenkins, this causes Jenkins to ignore it in favour
of its built in plugins, which it will install into ./foo.  This change means that
downloaded plugins will not have the version suffix, and thus be respected by jenkins properly.