### PR TITLE
Use JenkinsCore defaults when downloading deb from pkg.jenkins.io

### DIFF
--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -39,7 +39,7 @@ class Packages(object):
         self._apt = apt
         self._host = ch_host or host
         core_url = hookenv.config()["bundle-site"]
-        if core_url == "":
+        if core_url == "" or core_url == "https://pkg.jenkins.io":
             self._jc = JenkinsCore()
         else:
             self._jc = JenkinsCore(jenkins_core_url=hookenv.config()["bundle-site"])


### PR DESCRIPTION
This PR fix an issue where setting the bundle-site to https://pkg.jenkins.io will crash the charm when trying to download the jenkins package. That occurs because the official latestCore.txt file lives in https://updates.jenkins.io/stable/latestCore.txt.

When using a custom bundle-site, the charm expects that file to be under the same domain. This can't be expected from the official repository.