### PR TITLE
Discover both *.hpi and *.jpi files

### DIFF
--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -42,7 +42,7 @@ class Plugins(object):
 
         host.mkdir(
             paths.PLUGINS, owner="jenkins", group="jenkins", perms=0o0755)
-        existing_plugins = set(glob.glob("%s/*.jpi" % paths.PLUGINS))
+        existing_plugins = set(glob.glob("%s/*.?pi" % paths.PLUGINS))
         try:
             installed_plugins = self._install_plugins(plugins)
         except Exception:


### PR DESCRIPTION
In case the plugins are downloaded/installed as .hpi files, it should prevent the from being installed then removed.

Nonetheless, using .jpi format is the best path moving forward.