### PR TITLE
Correct charm source repo URL

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -10,4 +10,4 @@ options:
   basic:
     packages: ['net-tools', 'python3-testtools', 'pwgen']
     include_system_packages: true
-repo: https://github.com/freeekanayaka/layer-jenkins.git
+repo: https://github.com/jenkinsci/jenkins-charm

--- a/layer.yaml
+++ b/layer.yaml
@@ -10,4 +10,4 @@ options:
   basic:
     packages: ['net-tools', 'python3-testtools', 'pwgen']
     include_system_packages: true
-repo: https://github.com/jenkinsci/jenkins-charm
+repo: 'https://github.com/jenkinsci/jenkins-charm'


### PR DESCRIPTION
Charm source URL in layer.yaml is incorrect, and causing confusion. Fix it.