### PR TITLE
Fix invalid entry in wheelhouse.txt

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,3 @@
 # We require a version of python-jenkins that uses requests.
 python-jenkins>=0.4.16
-git+ssh://git.launchpad.net/jenkins-plugin-manager 
+-e git+ssh://git.launchpad.net/jenkins-plugin-manager#egg=jenkins-plugin-manager


### PR DESCRIPTION
wheelhouse.txt has an invalid entry, causing 'charm build' to explode.