### PR TITLE
Remove editable flag and use git+https

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,3 @@
 # We require a version of python-jenkins that uses requests.
 python-jenkins>=0.4.16
--e git+ssh://git.launchpad.net/jenkins-plugin-manager#egg=jenkins-plugin-manager
+git+https://git.launchpad.net/jenkins-plugin-manager#egg=jenkins-plugin-manager


### PR DESCRIPTION
Using "-e" is not recommended for production usage.
Also, git+https avoid git/ssh settings.