### PR TITLE
Plugin ownership

### DIFF
--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -88,6 +88,8 @@ class Plugins(object):
                 plugin_paths.add(plugin_path)
             else:
                 hookenv.log("Failed to download %s" % plugin)
+        # Make sure that the plugin directory is owned by jenkins
+        host.chownr(paths.PLUGINS, owner="jenkins", group="jenkins", chowntopdir=True)
         return plugin_paths
 
     def _install_plugin(self, plugin, plugins_site, update):


### PR DESCRIPTION
We had a situation where we ended with:

```
drwxr-xr-x  75 root    root    12288 Dec 11 03:57 plugins
drwxr-xr-x 138 jenkins nogroup 12288 Jul  1 09:50 plugins.old
drwxr-xr-x  75 root    root    12288 Dec 11 10:52 plugins_charm_backup
```

The logs in the unit suggest that something happened
```
2020-12-11 03:57:44 INFO juju-log Invoking reactive handler: reactive/jenkins.py:192:update_plugins
2020-12-11 03:57:44 INFO juju-log status-set: maintenance: Updating plugins
2020-12-11 03:57:45 INFO juju-log Backing up plugins.
2020-12-11 03:57:56 INFO juju-log Updating plugins
2020-12-11 03:57:56 INFO juju-log Installing plugins (junit jsch plain-credentials run-condition git-client workflow-basic-steps scm-api rebuild build-pipeline-plugin maven-plugin credentials-binding build-blocker-plugin cloudbees-folder jquery3-api workflow-scm-step credentials envinject bootstrap4-api openid4java font-awesome-api script-security matrix-combinations-parameter jquery matrix-project envinject-api token-macro git structs apache-httpcomponents-client-4-api mailer trilead-api bazaar jackson2-api ansicolor timestamper greenballs display-url-api javadoc durable-task parameterized-trigger copyartifact ssh-credentials echarts-api openid icon-shim checks-api workflow-job workflow-support workflow-step-api resource-disposer matrix-reloaded popper-api ws-cleanup matrix-auth nodelabelparameter snakeyaml-api conditional-buildstep email-ext build-timeout workflow-api plugin-util-api workflow-durable-task-step)
2020-12-11 03:57:57 INFO juju-log Installing plugin junit-1.46
2020-12-11 03:57:57 INFO juju-log Plugin jsch-0.1.55.2 already installed
```

Looking at the code, it makes "sense":
* In the charm itself [0]
* In jenkins-plugin-manager [1], the download happens without taking care of the permissions. Since it's juju
  running as root, it create the missing directory. it wasn't an issue before because the directory was existing
  with jenkins as an owner, which allowed jenkins to manipulate files inside the directory, even if owned by root.
* However, there is a host.mkdir earlier that should create the directory owned by jenins at least.
  It must be some kind of race condition, but the present PR allows all the plugins to be owned by the right user.

[0]: https://github.com/jenkinsci/jenkins-charm/blob/ba51e7f6ccbf0106a516b719732ad6df01e286c0/lib/charms/layer/jenkins/plugins.py#L104
[1]: https://git.launchpad.net/jenkins-plugin-manager/tree/jenkins_plugin_manager/plugin.py?id=27207ddcf25cc4a4417abe7498d5a79357cbe244#n161
