### PR TITLE
Set default password to reduce simple case deployment steps, and update maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ options:
       slave nodes so please don't change in Jenkins.
   password:
     type: string
-    default: ""
+    default: admin
     description: Admin user password - used to manage
       slave nodes so please don't change in Jenkins.
   plugins:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,7 @@
 name: jenkins
 summary: Jenkins Continuous Integration Server
-maintainer: Free Ekanayaka <free.ekanayaka@canonical.com>
+maintainers:
+  - launchpad.net/~canonical-is-sre
 description: >
   Jenkins is an extendable open source continuous integration server that
   monitors executions of repeated jobs. The focus of Jenkins is the

--- a/unit_tests/test_credentials.py
+++ b/unit_tests/test_credentials.py
@@ -70,8 +70,13 @@ class CredentialsTest(CharmTest):
         """
         If not set, the password is retrieved from the local state.
         """
-        self.useFixture(JenkinsConfiguredAdmin(self.fakes))
-        self.assertEqual(GENERATED_PASSWORD, self.credentials.password())
+        orig_password = hookenv.config()["password"]
+        try:
+            hookenv.config()["password"] = ""
+            self.useFixture(JenkinsConfiguredAdmin(self.fakes))
+            self.assertEqual(GENERATED_PASSWORD, self.credentials.password())
+        finally:
+            hookenv.config()["password"] = orig_password
 
     def test_token(self):
         """

--- a/unit_tests/test_users.py
+++ b/unit_tests/test_users.py
@@ -65,10 +65,17 @@ class UsersTest(JenkinsTest):
         def pwgen(length):
             return "z"
 
-        self.apt._set_jenkins_version('2.120.1')
-        script = UPDATE_PASSWORD_SCRIPT.format(username="admin", password="z")
-        self.fakes.jenkins.scripts[script] = ""
+        config = hookenv.config()
+        orig_password = config["password"]
+        try:
+            config["password"] = ""
 
-        self.useFixture(MonkeyPatch("charmhelpers.core.host.pwgen", pwgen))
-        self.users.configure_admin()
-        self.assertTrue(hookenv.config()["_generated-password"])
+            self.apt._set_jenkins_version('2.120.1')
+            script = UPDATE_PASSWORD_SCRIPT.format(username="admin", password="z")
+            self.fakes.jenkins.scripts[script] = ""
+
+            self.useFixture(MonkeyPatch("charmhelpers.core.host.pwgen", pwgen))
+            self.users.configure_admin()
+            self.assertTrue(hookenv.config()["_generated-password"])
+        finally:
+            config["password"] = orig_password


### PR DESCRIPTION
Set default password to reduce simple case deployment steps, and update maintainer