### PR TITLE
Allow downloads of .jpi and .hpi plugins

### DIFF
--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -92,6 +92,18 @@ class Plugins(object):
         host.chownr(paths.PLUGINS, owner="jenkins", group="jenkins", chowntopdir=True)
         return plugin_paths
 
+    def _install_hpi_or_jpi(self, plugin, plugin_path_no_suffix):
+        """
+        Plugins might be either .hpi or .jpi.
+        """
+        try:
+            return self._download_plugin(plugin, "%s.hpi" % plugin_path_no_suffix)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return self._download_plugin(plugin, "%s.jpi" % plugin_path_no_suffix)
+            else:
+                raise
+
     def _install_plugin(self, plugin, plugins_site, update):
         """
         Verify if the plugin is not installed before installing it
@@ -101,16 +113,7 @@ class Plugins(object):
         latest_version = self._get_latest_version(plugin)
         if not plugin_version or (update and plugin_version != latest_version):
             hookenv.log("Installing plugin %s-%s" % (plugin, latest_version))
-            # Plugins might be either .hpi or .jpi files.
-            try:
-                plugin_url = ("%s/%s.hpi" % (plugins_site, plugin))
-                return self._download_plugin(plugin, plugin_url)
-            except urllib.error.HTTPError as e:
-                if e.code == 404:
-                    plugin_url = ("%s/%s.jpi" % (plugins_site, plugin))
-                    return self._download_plugin(plugin, plugin_url)
-                else:
-                    raise
+            return self._install_hpi_or_jpi(plugin, "%s/%s" % (plugins_site, plugin))
         hookenv.log("Plugin %s-%s already installed" % (
             plugin, plugin_version))
 

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -92,16 +92,6 @@ class Plugins(object):
         host.chownr(paths.PLUGINS, owner="jenkins", group="jenkins", chowntopdir=True)
         return plugin_paths
 
-    def _install_hpi_or_jpi(self, plugin, plugin_url_no_suffix):
-        """Plugins might be either `.hpi` or `.jpi`."""
-        try:
-            return self._download_plugin(plugin, "%s.hpi" % plugin_url_no_suffix)
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                return self._download_plugin(plugin, "%s.jpi" % plugin_url_no_suffix)
-            else:
-                raise
-
     def _install_plugin(self, plugin, plugins_site, update):
         """
         Verify if the plugin is not installed before installing it
@@ -111,7 +101,7 @@ class Plugins(object):
         latest_version = self._get_latest_version(plugin)
         if not plugin_version or (update and plugin_version != latest_version):
             hookenv.log("Installing plugin %s-%s" % (plugin, latest_version))
-            return self._install_hpi_or_jpi(plugin, "%s/%s" % (plugins_site, plugin))
+            return self._download_hpi_or_jpi(plugin, "%s/%s" % (plugins_site, plugin))
         hookenv.log("Plugin %s-%s already installed" % (
             plugin, plugin_version))
 
@@ -135,6 +125,16 @@ class Plugins(object):
             return self._exclude_incompatible_plugins(plugins)
         else:
             return self._get_plugins_to_install(plugins_and_dependencies, uc)
+
+    def _download_hpi_or_jpi(self, plugin, plugin_url_no_suffix):
+        """Plugins might be either `.hpi` or `.jpi`."""
+        try:
+            return self._download_plugin(plugin, "%s.hpi" % plugin_url_no_suffix)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return self._download_plugin(plugin, "%s.jpi" % plugin_url_no_suffix)
+            else:
+                raise
 
     def _download_plugin(self, plugin, plugin_site):
         """Get dependencies of the given plugin(s)"""

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -101,9 +101,16 @@ class Plugins(object):
         latest_version = self._get_latest_version(plugin)
         if not plugin_version or (update and plugin_version != latest_version):
             hookenv.log("Installing plugin %s-%s" % (plugin, latest_version))
-            plugin_url = (
-                "%s/%s.hpi" % (plugins_site, plugin))
-            return self._download_plugin(plugin, plugin_url)
+            # Plugins might be either .hpi or .jpi files.
+            try:
+                plugin_url = ("%s/%s.hpi" % (plugins_site, plugin))
+                return self._download_plugin(plugin, plugin_url)
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    plugin_url = ("%s/%s.jpi" % (plugins_site, plugin))
+                    return self._download_plugin(plugin, plugin_url)
+                else:
+                    raise
         hookenv.log("Plugin %s-%s already installed" % (
             plugin, plugin_version))
 

--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -92,15 +92,13 @@ class Plugins(object):
         host.chownr(paths.PLUGINS, owner="jenkins", group="jenkins", chowntopdir=True)
         return plugin_paths
 
-    def _install_hpi_or_jpi(self, plugin, plugin_path_no_suffix):
-        """
-        Plugins might be either .hpi or .jpi.
-        """
+    def _install_hpi_or_jpi(self, plugin, plugin_url_no_suffix):
+        """Plugins might be either `.hpi` or `.jpi`."""
         try:
-            return self._download_plugin(plugin, "%s.hpi" % plugin_path_no_suffix)
+            return self._download_plugin(plugin, "%s.hpi" % plugin_url_no_suffix)
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                return self._download_plugin(plugin, "%s.jpi" % plugin_path_no_suffix)
+                return self._download_plugin(plugin, "%s.jpi" % plugin_url_no_suffix)
             else:
                 raise
 

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -72,7 +72,7 @@ class PluginsTest(CharmTest):
         mock_restart_jenkins.assert_called_with()
 
     @mock.patch("charms.layer.jenkins.plugins.Plugins._download_plugin")
-    def test_install_hpi_or_jpi(self, _download_plugin, mock_restart_jenkins):
+    def test_download_hpi_or_jpi(self, _download_plugin, mock_restart_jenkins):
         """
         A .hpi plugin doesn't exist, but a .jpi version does.
         """
@@ -88,7 +88,7 @@ class PluginsTest(CharmTest):
             True,
             urllib.error.HTTPError(code=403, msg="", url="", hdrs="", fp=io.StringIO("test")),
         ]
-        self.assertTrue(self.plugins._install_hpi_or_jpi('myplugin', 'http://x/myplugin'))
+        self.assertTrue(self.plugins._download_hpi_or_jpi('myplugin', 'http://x/myplugin'))
         _download_plugin.call_count = 2
         expected_calls = [
             mock.call('myplugin', 'http://x/myplugin.hpi'),
@@ -97,7 +97,7 @@ class PluginsTest(CharmTest):
         _download_plugin.assert_has_calls(expected_calls)
         with self.assertRaises(
                 urllib.error.HTTPError,
-                self.plugins._install_hpi_or_jpi,
+                self.plugins._download_hpi_or_jpi,
                 'myplugin',
                 'http://x/myplugin') as err:
             self.assertEqual(err.code, 403)


### PR DESCRIPTION
Currently we only allow download of `.hpi` plugins, but in some cases a `.jpi` file is available instead. Allow downloads of either.