### PR TITLE
If we have an invalid plugin, report that and set status to blocked

### DIFF
--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -184,6 +184,8 @@ def configure_plugins():
         installed_plugins, incompatible_plugins = plugins.install(config("plugins"))
         check_incompatible_plugins(incompatible_plugins)
     except InvalidPluginError as err:
+        log("Found one or more invalid plugins, check if they exist at %s. "
+            "Error was: %s" % (config("plugins-site"), str(err)), "ERROR")
         recover_jenkins(plugins)
         status_set("blocked", str(err))
         return

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -189,8 +189,14 @@ def configure_plugins():
         recover_jenkins(plugins)
         status_set("blocked", str(err))
         return
-    except Exception:
+    except Exception as err:
+        log("Unknown error encountered while installing plugins, restoring jenkins "
+            "to previous state. Error was: %s" % str(err), "ERROR")
         recover_jenkins(plugins)
+        # We should potentially set the charm to blocked status here and
+        # `return` to avoid the charm being set to active/idle with no
+        # indication to the operator of a problem. Leaving as is currently
+        # so we can see what errors occur.
     set_state("jenkins.configured.plugins")
     unitdata.kv().set("jenkins.plugins.last_update", time.time())
 

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -47,6 +47,8 @@ from charms.layer.jenkins.credentials import Credentials
 from charms.layer.jenkins.service import Service
 from charms.layer.jenkins.storage import Storage
 
+from jenkins_plugin_manager.exceptions import InvalidPluginError
+
 DEPENDENCIES_EVENTS = ["apt.installed.%s" % dep for dep in
                        APT_DEPENDENCIES[lsb_release()['DISTRIB_CODENAME']]]
 
@@ -181,6 +183,10 @@ def configure_plugins():
     try:
         installed_plugins, incompatible_plugins = plugins.install(config("plugins"))
         check_incompatible_plugins(incompatible_plugins)
+    except InvalidPluginError as err:
+        recover_jenkins(plugins)
+        status_set("blocked", str(err))
+        return
     except Exception:
         recover_jenkins(plugins)
     set_state("jenkins.configured.plugins")


### PR DESCRIPTION
This addresses https://github.com/jenkinsci/jenkins-charm/issues/111. Jenkins will be restored to its previous known good state, but Juju will report a blocked status, with a message such as `Cannot find plugin doesntexist`.