### PR TITLE
Stop using plugin-site to calc plugin-url

### DIFF
--- a/lib/charms/layer/jenkins/plugins.py
+++ b/lib/charms/layer/jenkins/plugins.py
@@ -99,7 +99,8 @@ class Plugins(object):
         latest_version = self._get_latest_version(plugin)
         if not plugin_version or (update and plugin_version != latest_version):
             hookenv.log("Installing plugin %s-%s" % (plugin, latest_version))
-            return self._download_plugin(plugin)
+            return self.update_center.download_plugin(
+                    plugin, paths.PLUGINS, with_version=False)
         hookenv.log("Plugin %s-%s already installed" % (
             plugin, plugin_version))
 
@@ -123,11 +124,6 @@ class Plugins(object):
             return self._exclude_incompatible_plugins(plugins)
         else:
             return self._get_plugins_to_install(plugins_and_dependencies, uc)
-
-    def _download_plugin(self, plugin):
-        """Get dependencies of the given plugin(s)"""
-        uc = self.update_center
-        return uc.download_plugin(plugin, paths.PLUGINS, with_version=False)
 
     def _get_plugin_info(self, plugin):
         """Get info of the given plugin from the UpdateCenter"""

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -71,37 +71,6 @@ class PluginsTest(CharmTest):
 
         mock_restart_jenkins.assert_called_with()
 
-    @mock.patch("charms.layer.jenkins.plugins.Plugins._download_plugin")
-    def test_download_hpi_or_jpi(self, _download_plugin, mock_restart_jenkins):
-        """
-        A .hpi plugin doesn't exist, but a .jpi version does.
-        """
-
-        # Our first download attempt will raise a 404, simulating a .hpi
-        # file not being found.
-        # Our second attempt returns True, simulating a successful download
-        # of a .jpi file.
-        # Our third attempt raises a 403, and we're confirming we re-raise
-        # that error, as it's not something we're expecting.
-        _download_plugin.side_effect = [
-            urllib.error.HTTPError(code=404, msg="", url="", hdrs="", fp=io.StringIO("test")),
-            True,
-            urllib.error.HTTPError(code=403, msg="", url="", hdrs="", fp=io.StringIO("test")),
-        ]
-        self.assertTrue(self.plugins._download_hpi_or_jpi('myplugin', 'http://x/myplugin'))
-        _download_plugin.call_count = 2
-        expected_calls = [
-            mock.call('myplugin', 'http://x/myplugin.hpi'),
-            mock.call('myplugin', 'http://x/myplugin.jpi'),
-        ]
-        _download_plugin.assert_has_calls(expected_calls)
-        with self.assertRaises(
-                urllib.error.HTTPError,
-                self.plugins._download_hpi_or_jpi,
-                'myplugin',
-                'http://x/myplugin') as err:
-            self.assertEqual(err.code, 403)
-
     @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
     def test_install_raises_error(self, mock_get_plugins_to_install, mock_get_plugin_version, mock_restart_jenkins):

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -190,7 +190,7 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
-    @mock.patch("test_plugins.Plugins._download_plugin")
+    @mock.patch("jenkins_plugin_manager.plugin.UpdateCenter.download_plugin")
     @mock.patch("test_plugins.Plugins._get_latest_version")
     @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")
@@ -226,7 +226,7 @@ class PluginsTest(CharmTest):
         finally:
             hookenv.config()["remove-unlisted-plugins"] = orig_remove_unlisted_plugins
 
-    @mock.patch("test_plugins.Plugins._download_plugin")
+    @mock.patch("jenkins_plugin_manager.plugin.UpdateCenter.download_plugin")
     @mock.patch("test_plugins.Plugins._get_latest_version")
     @mock.patch("charms.layer.jenkins.api.Api.get_plugin_version")
     @mock.patch("test_plugins.Plugins._get_plugins_to_install")


### PR DESCRIPTION
Closes #117 

Instead, trust jenkins_plugin_manager UpdateCenter to use consult
uc_data to find a more correct plugin_url

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Relevent issue: https://github.com/jenkinsci/jenkins-charm/issues/117

Summarising the issue, the way the charm determines the url to download plugins from is a little problematic. It makes assumptions which aren't always valid, and has lead to incorrect versions of plugins being downloaded (such as the credentials plugin as of writing).

So instead, I've delegated this task to `jenkins_plugin_manager`, which uses the `update-centre.json` provided by Jenkins to determine the correct url to download your plugin from (or at least, a url matching the version stated in the logs)
