### PR TITLE
Set pkg.jenkins.io as APT_SOURCE

### DIFF
--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -23,7 +23,7 @@ APT_DEPENDENCIES = {
     "bionic": ["daemon", "openjdk-8-jre-headless"],
     "focal": ["daemon", "openjdk-8-jre-headless"],
 }
-APT_SOURCE = "deb http://pkg.jenkins-ci.org/%s binary/"
+APT_SOURCE = "deb http://pkg.jenkins.io/%s binary/"
 
 
 class Packages(object):


### PR DESCRIPTION
It seems that jenkins has discontinued pkg.jenkins-ci.org as a mirror for pkg.jenkins.io and the charm is failing to install with:
```
unit-jenkins-3: 15:05:23 WARNING unit.jenkins/3.update-status E: Failed to fetch http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_2.346.1_all.deb  404  Not Found [IP: 52.202.51.185 80]
unit-jenkins-3: 15:05:23 WARNING unit.jenkins/3.update-status E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_2.263.4_all.deb returns 404 but its replacement works: https://pkg.jenkins.io/debian-stable/binary/jenkins_2.346.1_all.deb

I've tested this change locally.