### PR TITLE
Support Jenkins 2.361 and migrate basic integration tests to pytest operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.swp
 lib/charms/__init__.py
 lib/charms/layer/__init__.py
+venv

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -18,11 +18,7 @@ from jenkins_plugin_manager.core import JenkinsCore
 #     can be safely ignored since we're stubbing out these objects).
 apt = try_import("charms.apt")
 
-APT_DEPENDENCIES = {
-    "xenial": ["daemon", "default-jre-headless"],
-    "bionic": ["daemon", "openjdk-8-jre-headless"],
-    "focal": ["daemon", "openjdk-11-jre-headless"],
-}
+APT_DEPENDENCIES = ["daemon", "default-jre-headless"]
 APT_SOURCE = "deb http://pkg.jenkins.io/%s binary/"
 
 
@@ -51,7 +47,7 @@ class Packages(object):
     def install_dependencies(self):
         """Install the deb dependencies of the Jenkins package."""
         hookenv.log("Installing jenkins dependencies and desired tools")
-        self._apt.queue_install(APT_DEPENDENCIES[self.distro_codename()])
+        self._apt.queue_install(APT_DEPENDENCIES)
 
     def install_tools(self):
         """Install the configured tools."""

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -84,9 +84,7 @@ class Packages(object):
             self._jc.jenkins_repo = hookenv.config()["bundle-site"]
             download_path = os.path.join(hookenv.charm_dir(), "files")
             self._bundle_download(download_path)
-            bundle_path = os.path.join(
-                download_path, "jenkins_%s_all.deb" % self._jc.core_version
-            )
+            bundle_path = os.path.join(download_path, "jenkins_%s_all.deb" % self._jc.core_version)
         hookenv.log("Installing from bundled Jenkins package: %s:" % bundle_path)
         self._install_local_deb(bundle_path)
 

--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -21,7 +21,7 @@ apt = try_import("charms.apt")
 APT_DEPENDENCIES = {
     "xenial": ["daemon", "default-jre-headless"],
     "bionic": ["daemon", "openjdk-8-jre-headless"],
-    "focal": ["daemon", "openjdk-8-jre-headless"],
+    "focal": ["daemon", "openjdk-11-jre-headless"],
 }
 APT_SOURCE = "deb http://pkg.jenkins.io/%s binary/"
 
@@ -46,7 +46,7 @@ class Packages(object):
 
     def distro_codename(self):
         """Return the distro release code name, e.g. 'precise' or 'trusty'."""
-        return self._host.lsb_release()['DISTRIB_CODENAME']
+        return self._host.lsb_release()["DISTRIB_CODENAME"]
 
     def install_dependencies(self):
         """Install the deb dependencies of the Jenkins package."""
@@ -65,14 +65,14 @@ class Packages(object):
         release = config["release"]
         if release == "bundle":
             self._install_from_bundle()
-        elif release.startswith('http'):
+        elif release.startswith("http"):
             self._install_from_remote_deb(release)
         else:
             self._setup_source(release)
         self._apt.queue_install(["jenkins"])
 
     def jenkins_version(self):
-        return self._apt.get_package_version('jenkins', full_version=True)
+        return self._apt.get_package_version("jenkins", full_version=True)
 
     def _install_from_bundle(self):
         """Install Jenkins from bundled package."""
@@ -88,9 +88,10 @@ class Packages(object):
             self._jc.jenkins_repo = hookenv.config()["bundle-site"]
             download_path = os.path.join(hookenv.charm_dir(), "files")
             self._bundle_download(download_path)
-            bundle_path = os.path.join(download_path, "jenkins_%s_all.deb" % self._jc.core_version)
-        hookenv.log(
-            "Installing from bundled Jenkins package: %s:" % bundle_path)
+            bundle_path = os.path.join(
+                download_path, "jenkins_%s_all.deb" % self._jc.core_version
+            )
+        hookenv.log("Installing from bundled Jenkins package: %s:" % bundle_path)
         self._install_local_deb(bundle_path)
 
     def _install_local_deb(self, filename):
@@ -102,7 +103,7 @@ class Packages(object):
         """Install Jenkins from http(s) deb file."""
         hookenv.log("Getting remote jenkins package: %s" % url)
         tempdir = tempfile.mkdtemp()
-        target = os.path.join(tempdir, 'jenkins.deb')
+        target = os.path.join(tempdir, "jenkins.deb")
         subprocess.check_call(("wget", "-q", "-O", target, url))
         self._install_local_deb(target)
         shutil.rmtree(tempdir)
@@ -130,20 +131,18 @@ class Packages(object):
         self._apt.add_source(source, key=key)
 
     def _bundle_download(self, path=None):
-        hookenv.log(
-            "Downloading bundle from %s" % self._jc.jenkins_repo)
+        hookenv.log("Downloading bundle from %s" % self._jc.jenkins_repo)
         self._jc.get_binary_package(path)
 
     def jenkins_upgradable(self):
         """
-            Verify if there's a new version of jenkins available.
-            Note: When bundle-site is not set the return will always
-            be True.
+        Verify if there's a new version of jenkins available.
+        Note: When bundle-site is not set the return will always
+        be True.
         """
         if hookenv.config()["bundle-site"] == "":
             return True
-        if (parse_version(self._jc.core_version) >
-                parse_version(self.jenkins_version())):
+        if parse_version(self._jc.core_version) > parse_version(self.jenkins_version()):
             return True
         return False
 

--- a/lib/charms/layer/jenkins/users.py
+++ b/lib/charms/layer/jenkins/users.py
@@ -27,16 +27,24 @@ class Users(object):
         # Save the password to a file. It's not used directly by this charm
         # but it's convenient for integration with third-party tools.
         host.write_file(
-            paths.ADMIN_PASSWORD, admin.password.encode("utf-8"),
-            owner="root", group="root", perms=0o0600)
+            paths.ADMIN_PASSWORD,
+            admin.password.encode("utf-8"),
+            owner="root",
+            group="root",
+            perms=0o0600,
+        )
 
         if not os.path.exists(paths.LAST_EXEC):
             # This mean it's the very first time we configure the user,
             # and we want to create this file in order to avoid Jenkins
             # presenting the setup wizard.
             host.write_file(
-                paths.LAST_EXEC, "{}\n".format(api.version()).encode("utf-8"),
-                owner="jenkins", group="nogroup", perms=0o0600)
+                paths.LAST_EXEC,
+                "{}\n".format(api.version()).encode("utf-8"),
+                owner="jenkins",
+                group="nogroup",
+                perms=0o0600,
+            )
 
     def _admin_data(self):
         """Get a named tuple holding configuration data for the admin user."""
@@ -50,4 +58,4 @@ class Users(object):
         return _User(username, password)
 
 
-_User = namedtuple("User", ["username", "password"])
+_User = namedtuple("_User", ["username", "password"])

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display-name: Jenkins
 docs: https://discourse.charmhub.io/t/jenkins-docs-index/4831
 summary: Jenkins Continuous Integration Server
 maintainers:
-  - launchpad.net/~canonical-is-sre
+  - IS SRE <launchpad.net/~canonical-is-sre>
 description: >
   Jenkins is an extendable open source continuous integration server that
   monitors executions of repeated jobs. The focus of Jenkins is the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -140,9 +140,7 @@ def configure_tools():
 # Called once we're bootstrapped and every time the configured user
 # changes.
 @when("jenkins.bootstrapped")
-@when_any(
-    "config.changed.username", "config.changed.password", "config.changed.public-url"
-)
+@when_any("config.changed.username", "config.changed.password", "config.changed.public-url")
 def configure_admin():
     remove_state("jenkins.configured.admin")
     api = Api()
@@ -232,9 +230,7 @@ def update_plugins():
     unitdata.kv().set("jenkins.plugins.last_update", time.time())
 
 
-@when(
-    "jenkins.configured.tools", "jenkins.configured.admin", "jenkins.configured.plugins"
-)
+@when("jenkins.configured.tools", "jenkins.configured.admin", "jenkins.configured.plugins")
 def ready():
     status_set("active", "Jenkins is running")
 
@@ -252,9 +248,7 @@ def add_slaves(master):
         return
     api = Api()
     for slave in slaves:
-        api.add_node(
-            slave["slavehost"], slave["executors"], labels=slave["labels"] or ()
-        )
+        api.add_node(slave["slavehost"], slave["executors"], labels=slave["labels"] or ())
         secret = api.get_node_secret(slave["slavehost"])
         relation_set(secret=secret)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,13 +3,12 @@
 
 from pathlib import Path
 
-
+import jenkins
+from ops.model import Application, ActiveStatus
 import pytest_asyncio
-import yaml
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
-from ops.model import Application, ActiveStatus
-import jenkins
+import yaml
 
 from .types import JenkinsCredentials
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,12 +5,16 @@ import copy
 from pathlib import Path
 
 
+import pytest
 import pytest_asyncio
 import yaml
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
 from ops.model import Application
 from ops.model import Application
+import jenkins
+
+from .types import JenkinsCredentials
 
 
 @fixture(scope="module")
@@ -34,6 +38,46 @@ async def app(ops_test: OpsTest, app_name: str):
     application = await ops_test.model.deploy(
         charm, application_name=app_name, series="focal"
     )
-    await ops_test.model.wait_for_idle()
+    # Jenkins takes a while to install, setting timeout to 30 minutes
+    await ops_test.model.wait_for_idle(timeout=30 * 60)
 
     yield application
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_with_groovy(ops_test: OpsTest, app: Application):
+    """Add a groovy plugins to jenkins."""
+    original_config = await app.get_config()
+    new_config = copy.deepcopy(original_config)
+    new_config["plugins"] = "groovy"
+    await app.set_config(new_config)
+    await ops_test.model.wait_for_idle()
+
+    yield app
+
+    # Revert to previous config
+    await app.set_config(original_config)
+    await ops_test.model.wait_for_idle()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def jenkins_credentials(app: Application):
+    """Get the jenkins credentials."""
+    admin_credentials_action = await app.units[0].run_action("get-admin-credentials")
+    await admin_credentials_action.wait()
+
+    return JenkinsCredentials(
+        username=admin_credentials_action.results["username"],
+        password=admin_credentials_action.results["password"],
+    )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def jenkins_cli(app: Application, jenkins_credentials: JenkinsCredentials):
+    """Create a CLI to jenkins."""
+    url = f"http://{app.units[0].public_address}:8080"
+    return jenkins.Jenkins(
+        url=url,
+        username=jenkins_credentials.username,
+        password=jenkins_credentials.password,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,8 +57,10 @@ async def jenkins_url(app: Application):
     """Get the jenkins url."""
     public_address = app.units[0].public_address
     # Calculate host ensuring IPv6 support
-    host = public_address if ":" not in public_address else f"[{public_address}]"
-    return f"http://{host}:8080"
+    host = (
+        public_address if ":" not in public_address else "[{}]".format(public_address)
+    )
+    return "http://{}:8080".format(host)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,9 +31,7 @@ async def app(ops_test: OpsTest, app_name: str):
     Builds the charm and deploys the charm.
     """
     charm = await ops_test.build_charm(".")
-    application = await ops_test.model.deploy(
-        charm, application_name=app_name, series="focal"
-    )
+    application = await ops_test.model.deploy(charm, application_name=app_name, series="focal")
     # Jenkins takes a while to install, setting timeout to 30 minutes
     await ops_test.model.wait_for_idle(timeout=30 * 60, status=ActiveStatus.name)
 
@@ -57,16 +55,12 @@ async def jenkins_url(app: Application):
     """Get the jenkins url."""
     public_address = app.units[0].public_address
     # Calculate host ensuring IPv6 support
-    host = (
-        public_address if ":" not in public_address else "[{}]".format(public_address)
-    )
+    host = public_address if ":" not in public_address else "[{}]".format(public_address)
     return "http://{}:8080".format(host)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def jenkins_cli(
-    app: Application, jenkins_credentials: JenkinsCredentials, jenkins_url: str
-):
+async def jenkins_cli(app: Application, jenkins_credentials: JenkinsCredentials, jenkins_url: str):
     """Create a CLI to jenkins."""
     return jenkins.Jenkins(
         url=jenkins_url,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import copy
+from pathlib import Path
+
+
+import pytest_asyncio
+import yaml
+from pytest import fixture
+from pytest_operator.plugin import OpsTest
+from ops.model import Application
+from ops.model import Application
+
+
+@fixture(scope="module")
+def metadata():
+    """Provides charm metadata."""
+    yield yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@fixture(scope="module")
+def app_name(metadata):
+    """Provides app name from the metadata."""
+    yield metadata["name"]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app(ops_test: OpsTest, app_name: str):
+    """Jenkins charm used for integration testing.
+    Builds the charm and deploys the charm.
+    """
+    charm = await ops_test.build_charm(".")
+    application = await ops_test.model.deploy(
+        charm, application_name=app_name, series="focal"
+    )
+    await ops_test.model.wait_for_idle()
+
+    yield application

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,12 +2,10 @@
 # See LICENSE file for licensing details.
 
 import secrets
-import copy
 import pathlib
 import pytest
 from ops.model import ActiveStatus, Application
 
-import pytest_asyncio
 from pytest_operator.plugin import OpsTest
 import jenkins
 
@@ -188,3 +186,53 @@ async def test_tool_change(ops_test: OpsTest, app_restore_configuration: Applica
 
     dpkg_output = await app_restore_configuration.units[0].ssh("dpkg -l python3-lxml")
     assert "ii" in dpkg_output, "No tool installation found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_upgrade(ops_test: OpsTest, app_restore_configuration: Application):
+    """
+    arrange: given jenkins that is running
+    act: when the configuration is changed to bundle, a previous jre and version of jenkins is
+        installed and the upgrade action is run
+    assert: then the the jre version is moved back to the default version and jenkins is upgraded.
+    """
+    # Set release to bundle to be able to trigger the upgrade action
+    config = await app_restore_configuration.get_config()
+    config["release"] = "bundle"
+    config["bundle-site"] = "https://pkg.jenkins.io"
+    await app_restore_configuration.set_config(config)
+    await ops_test.model.wait_for_idle(status=ActiveStatus.name)
+    # Remove current Java and Jenkins version
+    await app_restore_configuration.units[0].ssh(
+        "sudo apt remove -y default-jre-headless jenkins"
+    )
+    # Install previous Java and Jenkins version
+    jenkins_version = "2.346.1"
+    await app_restore_configuration.units[0].ssh(
+        f"sudo apt-get install -y openjdk-8-jre-headless jenkins={jenkins_version}"
+    )
+    # Restart and check that jenkins is running
+    await app_restore_configuration.units[0].ssh("sudo systemctl restart jenkins")
+    systemctl_output = await app_restore_configuration.units[0].ssh(
+        "sudo systemctl status jenkins"
+    )
+    assert (
+        "active (running)" in systemctl_output
+    ), "Jenkins did not start after downgrade"
+    # Execute upgrade action
+    action = await app_restore_configuration.units[0].run_action("upgrade")
+    await action.wait()
+    await ops_test.model.wait_for_idle(status=ActiveStatus.name)
+
+    # Check that jenkins is running
+    systemctl_output = await app_restore_configuration.units[0].ssh(
+        "sudo systemctl status jenkins"
+    )
+    assert "active (running)" in systemctl_output, "Jenkins did not start after upgrade"
+    # Check version of jenkins that is installed
+    jenkins_output = await app_restore_configuration.units[0].ssh("jenkins --version")
+    assert jenkins_version not in jenkins_output
+    # Check java version
+    java_output = await app_restore_configuration.units[0].ssh("java --version")
+    assert "openjdk 8." not in java_output

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,9 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import asyncio
 import pathlib
-import re
 import secrets
 
 from ops.model import ActiveStatus, Application

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,92 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import re
+import pathlib
+import pytest
+from ops.model import ActiveStatus, Application
+
+PLUGINS_DIR = pathlib.Path("/var/lib/jenkins/plugins")
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_active(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when the status is checked
+    assert: then the status is active and a message which contains running has been set
+    """
+    assert app.units[0].workload_status == ActiveStatus.name
+    assert "running" in app.units[0].workload_status_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_debian_stable_in_sources(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when /etc/apt/sources.list is checked
+    assert: then it contains debian-stable
+    """
+    souces_list_contents = await app.units[0].ssh("cat /etc/apt/sources.list")
+
+    assert "debian-stable" in souces_list_contents, "LTS not in sources.list"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_tools_installed(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when checking for the python3-testtools package
+    assert: then it is found
+    """
+    dpkg_output = await app.units[0].ssh("dpkg -l python3-testtools")
+
+    assert "ii" in dpkg_output, "No tool installation found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_jenkins_user_exists(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when the existence of the jenkins user is checked
+    assert: then it is found
+    """
+    id_output = await app.units[0].ssh("id -u jenkins")
+
+    assert "no such user" not in id_output, "No Jenkins system user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_jenkins_service_running(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when the jenkins service is checked for
+    assert: then it is running
+    """
+    service_output = await app.units[0].ssh("service jenkins status")
+
+    assert "active (running)" in service_output, "No Jenkins Service Running"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_groovy_plugin_installed(app: Application):
+    """
+    arrange: given charm has been deployed and is idle
+    act: when the plguins directory is checked for the groovy plugin
+    assert: then it exists and its directory is not empty
+    """
+    stat_output = await app.units[0].ssh(f"stat {PLUGINS_DIR / 'groovy'}")
+
+    assert "No such file or directory" not in stat_output, "Failed to locate plugin"
+    # Get the size of the directory
+    size_regex = r"Size: (\d+)"
+    match = re.search(size_regex, stat_output)
+    assert match is not None, "stat did not return Size"
+    size = int(match.group(1))
+    assert size > 0, "Failed to locate plugin"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,7 +1,9 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import pathlib
+import re
 import secrets
 
 from ops.model import ActiveStatus, Application
@@ -50,6 +52,7 @@ async def test_tools_installed(app: Application):
     """
     dpkg_output = await app.units[0].ssh("dpkg -l python3-testtools")
 
+    # Check for ii in the output which indicates that the queried package is installed
     assert "ii" in dpkg_output, "No tool installation found"
 
 
@@ -96,9 +99,7 @@ async def test_jenkins_cli_whoami(
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_groovy_installed(
-    ops_test: OpsTest, app_restore_configuration: Application
-):
+async def test_groovy_installed(ops_test: OpsTest, app_restore_configuration: Application):
     """
     arrange: given charm has been deployed
     act: when the groovy plugin is added to the configuration
@@ -109,9 +110,7 @@ async def test_groovy_installed(
     await app_restore_configuration.set_config(config)
     await ops_test.model.wait_for_idle()
 
-    find_output = await app_restore_configuration.units[0].ssh(
-        "find {}".format(PLUGINS_DIR)
-    )
+    find_output = await app_restore_configuration.units[0].ssh("find {}".format(PLUGINS_DIR))
 
     assert "groovy.jpi" in find_output, "Failed to locate groovy"
 
@@ -188,63 +187,5 @@ async def test_tool_change(ops_test: OpsTest, app_restore_configuration: Applica
     await ops_test.model.wait_for_idle()
 
     dpkg_output = await app_restore_configuration.units[0].ssh("dpkg -l python3-lxml")
+    # Check for ii in the output which indicates that the queried package is installed
     assert "ii" in dpkg_output, "No tool installation found"
-
-
-@pytest.mark.asyncio
-@pytest.mark.abort_on_fail
-async def test_upgrade(ops_test: OpsTest, app_restore_configuration: Application):
-    """
-    arrange: given jenkins that is running
-    act: when the configuration is changed to bundle, a previous jre and version of jenkins is
-        installed and the upgrade action is run
-    assert: then the the jre version is moved back to the default version and jenkins is upgraded.
-    """
-    # Set release to bundle to be able to trigger the upgrade action
-    config = await app_restore_configuration.get_config()
-    config["release"] = "bundle"
-    config["bundle-site"] = "https://pkg.jenkins.io"
-    await app_restore_configuration.set_config(config)
-    await ops_test.model.wait_for_idle(status=ActiveStatus.name)
-    # Remove current Java and Jenkins version
-    await app_restore_configuration.units[0].ssh(
-        "sudo apt remove -y default-jre-headless jenkins"
-    )
-    # Install previous Java and Jenkins version
-    jenkins_version = "2.346.1"
-    await app_restore_configuration.units[0].ssh(
-        "sudo apt-get install -y openjdk-8-jre-headless jenkins={}".format(
-            jenkins_version
-        )
-    )
-    # Restart and check that jenkins is running
-    await app_restore_configuration.units[0].ssh("sudo systemctl restart jenkins")
-    systemctl_output = await app_restore_configuration.units[0].ssh(
-        "sudo systemctl status jenkins"
-    )
-    assert (
-        "active (running)" in systemctl_output
-    ), "Jenkins did not start after downgrade"
-    # Check version of jenkins that is installed
-    jenkins_output = await app_restore_configuration.units[0].ssh("jenkins --version")
-    assert jenkins_version in jenkins_output
-    # Check java version
-    java_output = await app_restore_configuration.units[0].ssh("java --version")
-    assert "openjdk 8." in java_output
-
-    # Execute upgrade action
-    action = await app_restore_configuration.units[0].run_action("upgrade")
-    await action.wait()
-    await ops_test.model.wait_for_idle(status=ActiveStatus.name)
-
-    # Check that jenkins is running
-    systemctl_output = await app_restore_configuration.units[0].ssh(
-        "sudo systemctl status jenkins"
-    )
-    assert "active (running)" in systemctl_output, "Jenkins did not start after upgrade"
-    # Check version of jenkins that is installed
-    jenkins_output = await app_restore_configuration.units[0].ssh("jenkins --version")
-    assert jenkins_version not in jenkins_output
-    # Check java version
-    java_output = await app_restore_configuration.units[0].ssh("java --version")
-    assert "openjdk 8." not in java_output

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -102,7 +102,7 @@ async def test_groovy_installed(
     """
     arrange: given charm has been deployed
     act: when the groovy plugin is added to the configuration
-    assert: then the .hpi files for the plugin is found in the plugins directory.
+    assert: then the .jpi files for the plugin is found in the plugins directory.
     """
     config = await app_restore_configuration.get_config()
     config["plugins"] = "groovy"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,10 +1,11 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import secrets
 import pathlib
-import pytest
+import secrets
+
 from ops.model import ActiveStatus, Application
+import pytest
 
 from pytest_operator.plugin import OpsTest
 import jenkins

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Useful types for integration tests."""
+
+import typing
+
+
+class JenkinsCredentials(typing.NamedTuple):
+    """Credentials for Jenkins."""
+
+    username: str
+    password: str

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,4 @@ deps =
     ops
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore=unit_tests --log-cli-level=INFO -s {posargs}
+    pytest --pdb -v --tb native --ignore=unit_tests --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,4 @@ deps =
     ops
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --pdb -v --tb native --ignore=unit_tests --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore=unit_tests --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,19 @@
 [tox]
 skipsdist=True
-envlist = py35
 skip_missing_interpreters = True
 
 [testenv]
+basepython = python3.8
+
+[testenv:unit]
 whitelist_externals =
     touch
     rm
 commands =
+    ; Check for Python 3.5 compatibility to ensure Xenial support
+    mypy --ignore-missing-imports --python-version 3.5 {toxinidir}/lib {posargs}
+    mypy --ignore-missing-imports --python-version 3.5 {toxinidir}/reactive {posargs}
+    ; Execute unit tests
     touch {toxinidir}/lib/charms/__init__.py
     touch {toxinidir}/lib/charms/layer/__init__.py
     coverage erase
@@ -21,6 +27,9 @@ deps =
     charm-test>=0.2.0
     fakesleep
     coverage
+    mypy
+    types-setuptools
+    types-requests
 setenv =
     PYTHONPATH = {toxinidir}/lib/
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,15 @@ setenv =
 
 [flake8]
 exclude=docs
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    pytest-asyncio
+    ops
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest --pdb -v --tb native --ignore=unit_tests --log-cli-level=INFO -s {posargs}

--- a/unit_tests/test_packages.py
+++ b/unit_tests/test_packages.py
@@ -25,7 +25,6 @@ from charms.layer.jenkins.packages import (
 
 
 class PackagesTest(CharmTest):
-
     def setUp(self):
         super(PackagesTest, self).setUp()
         self.apt = AptStub()
@@ -34,8 +33,10 @@ class PackagesTest(CharmTest):
         # XXX Not all charm files are populated in charm_dir() by default.
         # XXX See: https://github.com/freeekanayaka/charm-test/issues/2
         keyfile = "jenkins.io.key"
-        os.symlink(os.path.join(os.getcwd(), keyfile),
-                   os.path.join(hookenv.charm_dir(), keyfile))
+        os.symlink(
+            os.path.join(os.getcwd(), keyfile),
+            os.path.join(hookenv.charm_dir(), keyfile),
+        )
 
         jenkins_cache_dir = "/var/cache/jenkins/war/WEB-INF"
         self.fakes.fs.add(paths.PLUGINS)
@@ -55,15 +56,15 @@ class PackagesTest(CharmTest):
         method.
         """
         # Our default distro version (xenial).
-        self.assertEqual(self.packages.distro_codename(), 'xenial')
+        self.assertEqual(self.packages.distro_codename(), "xenial")
         self.packages.install_dependencies()
-        self.assertEqual(APT_DEPENDENCIES['xenial'], self.apt.installs)
+        self.assertEqual(APT_DEPENDENCIES, self.apt.installs)
         # Now check with a distro of bionic.
         self.apt.installs = []
-        self.ch_host._set_distro_version('bionic')
-        self.assertEqual(self.packages.distro_codename(), 'bionic')
+        self.ch_host._set_distro_version("bionic")
+        self.assertEqual(self.packages.distro_codename(), "bionic")
         self.packages.install_dependencies()
-        self.assertEqual(APT_DEPENDENCIES['bionic'], self.apt.installs)
+        self.assertEqual(APT_DEPENDENCIES, self.apt.installs)
 
     def test_install_tools(self):
         """
@@ -91,8 +92,7 @@ class PackagesTest(CharmTest):
             with open(bundle_path, "w") as fd:
                 fd.write("")
             self.packages.install_jenkins()
-            self.assertEqual(
-                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+            self.assertEqual(["install"], self.fakes.processes.dpkg.actions["jenkins"])
         finally:
             hookenv.config()["release"] = orig_release
 
@@ -108,8 +108,8 @@ class PackagesTest(CharmTest):
             self.assertThat(path, Not(PathExists()))
             error = self.assertRaises(Exception, self.packages._install_from_bundle)
             self.assertEqual(
-                "'{}' doesn't exist. No package bundled.".format(path),
-                str(error))
+                "'{}' doesn't exist. No package bundled.".format(path), str(error)
+            )
         finally:
             hookenv.config()["release"] = orig_release
 
@@ -118,14 +118,12 @@ class PackagesTest(CharmTest):
         If the 'release' config is set to a remote URL, then Jenkins will be
         installed from the deb files pointed by that url.
         """
-        self.fakes.processes.wget.locations[
-            "http://jenkins-1.2.3.deb"] = b"data"
+        self.fakes.processes.wget.locations["http://jenkins-1.2.3.deb"] = b"data"
         orig_release = hookenv.config()["release"]
         try:
             hookenv.config()["release"] = "http://jenkins-1.2.3.deb"
             self.packages.install_jenkins()
-            self.assertEqual(
-                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+            self.assertEqual(["install"], self.fakes.processes.dpkg.actions["jenkins"])
         finally:
             hookenv.config()["release"] = orig_release
 
@@ -166,16 +164,15 @@ class PackagesTest(CharmTest):
         try:
             hookenv.config()["release"] = "foo"
             error = self.assertRaises(Exception, self.packages.install_jenkins)
-            self.assertEqual(
-                "Release 'foo' configuration not recognised", str(error))
+            self.assertEqual("Release 'foo' configuration not recognised", str(error))
         finally:
             hookenv.config()["release"] = orig_release
 
     def test_jenkins_version(self):
-        self.assertEqual(self.packages.jenkins_version(), '2.150.1')
+        self.assertEqual(self.packages.jenkins_version(), "2.150.1")
         # And now test older version.
-        self.apt._set_jenkins_version('2.128.1')
-        self.assertEqual(self.packages.jenkins_version(), '2.128.1')
+        self.apt._set_jenkins_version("2.128.1")
+        self.assertEqual(self.packages.jenkins_version(), "2.128.1")
 
     def test_jenkins_upgradable_without_bundle_site(self):
         """
@@ -183,8 +180,8 @@ class PackagesTest(CharmTest):
         isn't set.
         """
         self.assertTrue(self.packages.jenkins_upgradable())
-        self.apt._set_jenkins_version('2.128.1')
-        self.packages._jc.core_version = '2.128.1'
+        self.apt._set_jenkins_version("2.128.1")
+        self.packages._jc.core_version = "2.128.1"
         self.assertTrue(self.packages.jenkins_upgradable())
 
     @mock.patch("charms.layer.jenkins.packages.JenkinsCore")
@@ -197,10 +194,10 @@ class PackagesTest(CharmTest):
         try:
             hookenv.config()["bundle-site"] = "http://test"
             self.packages = Packages(apt=self.apt, ch_host=self.ch_host)
-            self.apt._set_jenkins_version('2.128.1')
-            self.packages._jc.core_version = '2.128.2'
+            self.apt._set_jenkins_version("2.128.1")
+            self.packages._jc.core_version = "2.128.2"
             self.assertTrue(self.packages.jenkins_upgradable())
-            self.packages._jc.core_version = '2.128.1'
+            self.packages._jc.core_version = "2.128.1"
             self.assertFalse(self.packages.jenkins_upgradable())
         finally:
             hookenv.config()["bundle-site"] = orig_bundle_site
@@ -223,8 +220,7 @@ class PackagesTest(CharmTest):
             bundle_path = os.path.join(hookenv.charm_dir(), "files")
             self.packages.install_jenkins()
             self.assertTrue(len(os.listdir(bundle_path)) > 0)
-            self.assertEqual(
-                ["install"], self.fakes.processes.dpkg.actions["jenkins"])
+            self.assertEqual(["install"], self.fakes.processes.dpkg.actions["jenkins"])
         finally:
             hookenv.config()["release"] = orig_release
             hookenv.config()["bundle-site"] = orig_bundle_site
@@ -242,9 +238,12 @@ class PackagesTest(CharmTest):
             if value == "%s/*/" % paths.PLUGINS:
                 return ["/var/lib/jenkins/plugins/"]
             if value == "%s/*.jpi" % paths.PLUGINS:
-                return ["/var/lib/jenkins/plugins/test1_plugin.jpi",
-                        "/var/lib/jenkins/plugins/test2_plugin.jpi",
-                        "/var/lib/jenkins/plugins/test3_plugin.jpi"]
+                return [
+                    "/var/lib/jenkins/plugins/test1_plugin.jpi",
+                    "/var/lib/jenkins/plugins/test2_plugin.jpi",
+                    "/var/lib/jenkins/plugins/test3_plugin.jpi",
+                ]
+
         mock_os_glob.side_effect = side_effect
         os_expected_calls.append(mock.call("sudo rm -r %s/" % paths.PLUGINS))
 


### PR DESCRIPTION
- Changes to install the default jre version for all Ubuntu series
- Migrate the basic integration tests to pytest operator

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
