### PR TITLE
Chore: remove reversion to charm version 2.x in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-        # [2022-10-03] Use charm 2.x/stable as 3.x is not working
-      - name: Revert to charm 2.x
-        run: |
-          sudo snap remove charm
-          sudo snap install charm --channel=2.x/stable --classic
       - name: Run integration tests
         run: |
           tox -e integration -- -k ${{ matrix.module }} --series ${{ matrix.series }}


### PR DESCRIPTION
Removes reversion of charm snap to version 2.x

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
