### PR TITLE
Enable integration test with Jenkins agent charm on Xenial.

### DIFF
--- a/tests/integration/test_charm_agent.py
+++ b/tests/integration/test_charm_agent.py
@@ -82,7 +82,7 @@ async def agent(ops_test: OpsTest, series: str):
     agent_app_name = "jenkins-slave"
     # Agent currently does not support xenial
     agent: Application = await ops_test.model.deploy(
-        agent_app_name, series=series if series != "xenial" else "bionic", channel="edge"
+        agent_app_name, series=series, channel="edge"
     )
     # Don't wait for active because the agent will start blocked
     await ops_test.model.wait_for_idle()

--- a/tests/integration/test_charm_agent.py
+++ b/tests/integration/test_charm_agent.py
@@ -80,7 +80,6 @@ async def app_jenkins_version(
 async def agent(ops_test: OpsTest, series: str):
     """Deploy machine agent and destroy it after tests complete."""
     agent_app_name = "jenkins-slave"
-    # Agent currently does not support xenial
     agent: Application = await ops_test.model.deploy(
         agent_app_name, series=series, channel="stable"
     )

--- a/tests/integration/test_charm_agent.py
+++ b/tests/integration/test_charm_agent.py
@@ -82,7 +82,7 @@ async def agent(ops_test: OpsTest, series: str):
     agent_app_name = "jenkins-slave"
     # Agent currently does not support xenial
     agent: Application = await ops_test.model.deploy(
-        agent_app_name, series=series, channel="edge"
+        agent_app_name, series=series, channel="stable"
     )
     # Don't wait for active because the agent will start blocked
     await ops_test.model.wait_for_idle()


### PR DESCRIPTION
A new version of Jenkins agent charm was released to fix support for Xenial.
The integration test with Jenkins agent charm on Xenial was disabled.
This pull request re-enable the integration test.

I have ran ` tox -e integration -- -k agent` and the test result was successful.