### PR TITLE
fix(xenial): charm dependencies

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -8,6 +8,13 @@ includes:
   - interface:nrpe-external-master
 options:
   basic:
-    packages: ['net-tools', 'python3-testtools', 'pwgen']
+    packages:
+      - 'build-essential'
+      - 'net-tools'
+      - 'pwgen'
+      - 'python3-setuptools'
+      - 'python3-testtools'
+      - 'python3-wheel'
+      - 'python3-yaml'
     include_system_packages: true
 repo: 'https://github.com/jenkinsci/jenkins-charm'

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -11,3 +11,12 @@ urllib3<1.26.10
 # We require a version of python-jenkins that uses requests.
 python-jenkins>=0.4.16
 git+https://git.launchpad.net/jenkins-plugin-manager#egg=jenkins-plugin-manager
+
+MarkupSafe<2.0.0;python_version < '3.6'
+MarkupSafe<2.1.0;python_version >= '3.6' and python_version <= '3.8' # py38, focal
+MarkupSafe;python_version > '3.8'
+setuptools<42;python_version <= '3.8.10'
+setuptools;python_version > '3.8'
+setuptools-scm;python_version > '3.8'
+setuptools-scm<=1.17.0;python_version <= '3.6'
+setuptools-scm-git-archive;python_version <= '3.6'


### PR DESCRIPTION
- pin setuptools to an earlier version for < py36 (xenial) 
  ```
  File Finder Failed for .git = setuptools_scm.git:list_files_in_archive 
  ```
- preinstalling basic layer dependencies to avoid chicken and egg issues deploying on xenial

This [related](https://github.com/pypa/setuptools_scm/issues/164) issue provides more context.