### PR TITLE
feat: no-proxy configuration value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,6 +84,14 @@ options:
       If a proxy is required for Jenkins to download plugins and updates and
       authentication is also required, set the password here. Ignored if
       proxy-hostname and proxy-password are not both also set.
+  no-proxy:
+    type: string
+    default: ""
+    description: |
+      If a proxy is configured but some hosts should not go through the proxy, 
+      set the hostnames here. Ignored if any of the proxy settings above are not
+      set. Separated by commas. "*" is the wild card host name(such as
+      "*.jenkins.io" or "www*.jenkins-ci.org").
   remove-unlisted-plugins:
     type: string
     default: "no"

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -113,13 +113,13 @@ class Api(object):
     ):
         """Configure (or disable) a system proxy."""
         client = self._make_client()
-        if username and password and hostname and port and no_proxy_hosts:
+        if hostname and port and no_proxy_hosts:
             client.run_script(
                 CONFIGURE_PROXY_NO_PROXY_WITH_AUTH_SCRIPT.format(
                     hostname=hostname,
                     port=port,
-                    username=username,
-                    password=password,
+                    username=username or "",
+                    password=password or "",
                     no_proxy_hosts=no_proxy_hosts,
                 )
             )

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -44,7 +44,7 @@ Jenkins.instance.pluginManager.doSiteConfigure('{url}')
 """
 
 CONFIGURE_PROXY_NO_PROXY_WITH_AUTH_SCRIPT = """
-proxy = new ProxyConfiguration('{hostname}', {port}, '{username}', '{password}', '{noproxyhosts}')
+proxy = new ProxyConfiguration('{hostname}', {port}, '{username}', '{password}', '{no_proxy_hosts}')
 proxy.save()
 """
 

--- a/lib/charms/layer/jenkins/api.py
+++ b/lib/charms/layer/jenkins/api.py
@@ -1,14 +1,12 @@
-import requests
 import time
 from distutils.version import LooseVersion
 from urllib.parse import urljoin, urlparse
 
 import jenkins
+import requests
 from charmhelpers.core import hookenv, unitdata
-
 from charmhelpers.core.decorators import retry_on_exception
 from charmhelpers.core.hookenv import ERROR
-
 from charms.layer.jenkins.credentials import Credentials
 from charms.layer.jenkins.packages import Packages
 
@@ -43,6 +41,11 @@ user.addProperty(property)
 # flake8: noqa
 SET_UPDATE_CENTER_SCRIPT = """
 Jenkins.instance.pluginManager.doSiteConfigure('{url}')
+"""
+
+CONFIGURE_PROXY_NO_PROXY_WITH_AUTH_SCRIPT = """
+proxy = new ProxyConfiguration('{hostname}', {port}, '{username}', '{password}', '{noproxyhosts}')
+proxy.save()
 """
 
 CONFIGURE_PROXY_WITH_AUTH_SCRIPT = """
@@ -105,10 +108,22 @@ class Api(object):
             return False
         return version
 
-    def configure_proxy(self, hostname=None, port=None, username=None, password=None):
+    def configure_proxy(
+        self, hostname=None, port=None, username=None, password=None, no_proxy_hosts=None
+    ):
         """Configure (or disable) a system proxy."""
         client = self._make_client()
-        if username and password and hostname and port:
+        if username and password and hostname and port and no_proxy_hosts:
+            client.run_script(
+                CONFIGURE_PROXY_NO_PROXY_WITH_AUTH_SCRIPT.format(
+                    hostname=hostname,
+                    port=port,
+                    username=username,
+                    password=password,
+                    no_proxy_hosts=no_proxy_hosts,
+                )
+            )
+        elif username and password and hostname and port:
             client.run_script(
                 CONFIGURE_PROXY_WITH_AUTH_SCRIPT.format(
                     hostname=hostname, port=port, username=username, password=password

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -1,10 +1,7 @@
 import os
 from urllib.parse import urlparse
 
-from charmhelpers.core import hookenv
-from charmhelpers.core import host
-from charmhelpers.core import templating
-
+from charmhelpers.core import hookenv, host, templating
 from charms.layer.jenkins import paths
 from charms.layer.jenkins.api import Api
 
@@ -54,7 +51,8 @@ class Configuration(object):
             config["proxy-hostname"],
             config["proxy-port"],
             config["proxy-username"],
-            config["proxy-password"]
+            config["proxy-password"],
+            config["no-proxy"]
         )
 
     def migrate(self):

--- a/tests/integration/config.py
+++ b/tests/integration/config.py
@@ -3,7 +3,18 @@
 
 """Useful configuration for integration tests."""
 
+import dataclasses
 import pathlib
 
-
 PLUGINS_DIR = pathlib.Path("/var/lib/jenkins/plugins")
+
+
+@dataclasses.dataclass(frozen=True)
+class ProxyConfig:
+    """The Jenkins proxy configuration values."""
+
+    proxy_hostname: str
+    proxy_port: int
+    proxy_username: str
+    proxy_password: str
+    no_proxy: str


### PR DESCRIPTION
This PR addresses issue #148 and adds the `no_proxy` configuration setting to the charm.

### Testing done

`juju deploy ./jenkins_ubuntu-16.04-amd64_ubuntu-18.04-amd64_ubuntu-20.04-amd64.charm --series focal --config proxy-hostname=localhost --config proxy-port=8080 --config proxy-username=helloworld --config proxy-password=helloworld --config no-proxy=abc.com,def.net,10.200.114.151,localhost`
`jenkins_ubuntu-16.04-amd64_ubuntu-18.04-amd64_ubuntu-20.04-amd64.charm` refers to the charm built with code in current PR.

![image](https://github.com/jenkinsci/jenkins-charm/assets/37652070/e310e0b7-5bae-49e2-8277-d9ef20a1d8dd)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
