### PR TITLE
Bump systemd service timeout to allow enough time for Jenkins to start

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -30,3 +30,6 @@ jobs:
       - name: Run integration tests
         run: |
           tox -e integration -- -k ${{ matrix.module }} --series ${{ matrix.series }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           provider: lxd
           charm-channel: 2.x/stable
+          juju-channel: 2.9/stable
         # Python 3.8 is a required integreation test dependency.
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -30,6 +30,3 @@ jobs:
       - name: Run integration tests
         run: |
           tox -e integration -- -k ${{ matrix.module }} --series ${{ matrix.series }}
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -78,7 +78,7 @@ class Configuration(object):
                        the prefix config is unset.
         """
         # Since version 2.332.1 Jenkins is not loading env vars from the default config file
-        overrides_content = '# This file is managed by Juju. Do not edit manually.\n[Service]\nEnvironment="JENKINS_PREFIX={}"\n'.format(prefix)
+        overrides_content = '# This file is managed by Juju. Do not edit manually.\n[Service]\nEnvironment="JENKINS_PREFIX={}"\nTimeoutSec=900\n'.format(prefix)
 
         host.mkdir(os.path.dirname(paths.SERVICE_CONFIG_FILE_OVERRIDE), perms=0o751)
         with open(os.open(paths.SERVICE_CONFIG_FILE_OVERRIDE, os.O_CREAT | os.O_WRONLY, 0o644), 'w') as overrides_file:

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ commands =
     echo "Canceling the test before completion creates __init__.py files \
         which could cause undesired behaviours. Make sure to delete the __init__.py files manually."
     ; Check for Python 3.5 compatibility to ensure Xenial support
-    mypy --ignore-missing-imports --python-version 3.5 {toxinidir}/lib/charms/layer/jenkins {posargs}
-    mypy --ignore-missing-imports --python-version 3.5 {toxinidir}/reactive {posargs}
+    mypy --ignore-missing-imports --python-version 3.8 {toxinidir}/lib/charms/layer/jenkins {posargs}
+    mypy --ignore-missing-imports --python-version 3.8 {toxinidir}/reactive {posargs}
     ; Execute unit tests
     touch {toxinidir}/lib/charms/__init__.py
     touch {toxinidir}/lib/charms/layer/__init__.py


### PR DESCRIPTION
As seen with the stable-cloud-images Jenkins environment, it can get into a restart loop due to Jenkins not being started within the default 90 secs (`DefaultTimeoutStartSec`).

### Testing done

Observed Jenkins being restarted by systemd. Cowboyed this out and confirmed jenkins started successfully.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```